### PR TITLE
docs(theory): Phase 2 — study notes, solver reframe, hypotheses locked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ build/
 # Local-only project direction — not published to the remote
 roadmap-fliphex-v1.md
 
-# Claude Code config — local only, never published
+# Local-only tooling config — never published
 .claude/
 
 # Example source artifact (USP poster) — local only
@@ -24,3 +24,5 @@ data/selfplay/
 results/*.jsonl
 figures/*.png
 !figures/.gitkeep
+notes/sources/
+refs/

--- a/docs/adr/adr-004-solver-approach.md
+++ b/docs/adr/adr-004-solver-approach.md
@@ -78,9 +78,11 @@ adr-003 — 50 random words, O(1) incremental update per flip.
 
 **Neutral**
 
-- No board symmetries to canonicalise with (the board's symmetry group is
-  trivial, per adr-002), so the TT gets no free symmetry folding. Expected, but
-  it means TT hit rates will be lower than a Reversi solver's.
+- ~~No board symmetries to canonicalise with (the board's symmetry group is
+  trivial, per adr-002), so the TT gets no free symmetry folding.~~
+  **Superseded** — see the Phase 2 amendment below and
+  [adr-008](adr-008-board-mirror-symmetry.md): the board has a Z/2 mirror, and
+  it is usable for TT folding *in the endgame databases*.
 
 ## Alternatives considered
 
@@ -101,8 +103,70 @@ tractable, honest version of the same idea.
 with no strong non-learned opponent on the real game, and H3 becomes untestable
 where it matters most. Rejected.
 
+## Amendment — Phase 2 (2026-07-31): Allis 1994 grounding + intermediate-board frontier
+
+Reading Allis (1994) *Searching for Solutions* produced three refinements. None
+overturns the decision; two sharpen it and one corrects a stale premise.
+
+**1. Allis's taxonomy confirms alpha-beta + retrograde over proof-number
+search.** FLIPHEX classifies as **diverging** (a tile is *added* each ply) and
+**fixed-termination** (ends at ply 25 by board-fill, with no sudden-death
+pattern) — the Othello profile. Allis: endgame databases are creatable for
+*converging* games and "generally unfeasible for diverging" ones; and fixed
+termination "renders solving the game in similar fashion to the solution of
+qubic and go-moku impossible." Two consequences for this ADR:
+
+- Proof-number search (the alternative parked under *Alternatives considered*)
+  shines on **sudden-death** goal-proving — proving a forced threat sequence, as
+  in qubic and go-moku. FLIPHEX has no such goal to prove, so pn-search loses its
+  structural edge here. The reading therefore *strengthens* the original
+  alpha-beta + TT choice rather than reopening it.
+- The diverging nature is exactly *why* the retrograde databases must stay
+  shallow: the position count grows fast as you recede from the full board.
+  The `k ≤ 5` target is now justified, not merely assumed.
+
+**2. There is a solvable-and-rich intermediate board — the 4×4 (16 cells).**
+Computing the reachable bound (the adr-003 formula) across board sizes:
+
+| Board | cells | full 13-deck | reduced deck |
+|---|--:|--:|--:|
+| 3×3 | 9 | 3.1 × 10⁹ | 7.1 × 10⁵ |
+| 4×4 | 16 | 8.3 × 10¹³ | 9.3 × 10¹⁰ |
+| 5×5 (shipped) | 25 | — | 4.9 × 10¹⁷ |
+
+The full-enumeration frontier sits at **N ≈ 13–15** (≈10¹²–10¹³). This sharpens
+part 1 of the Decision ("solve 3×3, attempt 4×4"):
+
+- **3×3 is a correctness fixture, not a strategy microcosm.** At 9 cells it is
+  too cramped for tactics like deferring a flip to set up a larger later swing.
+  It validates the engine, the search, and the H3 cross-check — it is *not*
+  claimed to reveal 5×5 strategy, and the writeup must not imply otherwise.
+- **4×4 is promoted from "attempt" to the primary exact-solve target for
+  strategic claims.** 16 cells give room for spatial/tempo tactics, and
+  8.3 × 10¹³ (full deck) — or 9.3 × 10¹⁰ with a reduced deck, ~3 orders of
+  magnitude cheaper — is within reach of retrograde analysis on modern storage.
+  3×3 stays the fast calibration solve; 4×4 carries the H1/H2 exact verdicts.
+
+**3. Symmetry correction (supersedes the struck "Neutral" bullet).** The claim
+that the board's symmetry group is trivial is wrong — [adr-008](adr-008-board-mirror-symmetry.md)
+established a Z/2 left-right mirror. The mirror is a *game-level partial*
+symmetry: it holds only once **both** chiral `P3-y` tiles are placed and inert.
+That condition is met **precisely in the endgame** — exactly where the
+retrograde databases live. So the endgame DBs (and the TT within them) **can**
+fold mirror-image positions ~2×, a saving this ADR originally assumed
+unavailable. Full-game alpha-beta still gets no folding while a `P3-y` is in a
+hand.
+
+**Open item forwarded.** "Proportionally smaller decks" (Decision, part 1) is
+still undefined — *which* tiles a reduced board draws. That choice swings the
+4×4 bound by ~3 orders of magnitude (table above) and decides whether a reduced
+solve is a faithful shrink of FLIPHEX. Pinned in
+[adr-009](adr-009-reduced-deck-policy.md) (Proposed).
+
 ## Related
 
 - [adr-003](adr-003-piece-representation.md) — the state space this rests on
 - [adr-005](adr-005-alphazero-scope-and-network.md) — the axis this is compared against
+- [adr-008](adr-008-board-mirror-symmetry.md) — the mirror the endgame DBs can fold on
+- [adr-009](adr-009-reduced-deck-policy.md) — the reduced-deck policy this defers to
 - `docs/research.md` — H1, H2, H3

--- a/docs/adr/adr-004-solver-approach.md
+++ b/docs/adr/adr-004-solver-approach.md
@@ -165,10 +165,133 @@ solve is a faithful shrink of FLIPHEX. Pinned in
 ascending arrow count; reduced boards are a purely computational device
 (OPEN-3 resolved), so faithfulness is judged against the shipped 5×5.
 
+## Amendment — Phase 2 (2026-08-05): the two complexity axes, and what that changes
+
+Reading Schaeffer (2007) and R&N Ch.6 against Allis produced six refinements.
+The decision stands; two of its *justifications* were wrong, and one of the
+Alternatives is reopened in a narrower form.
+
+**1. The 5×5 infeasibility argument in Context is stated on the wrong axis.**
+"~4.9 × 10¹⁷ reachable states, far too many to enumerate, so the full 5×5 game is
+not weakly solvable" does not follow. Checkers has **5 × 10²⁰** states — about
+1000× more — and *was* weakly solved in 2007. State-space and game-tree
+complexity are independent axes (Allis §6.1), and a weak solution is bounded by
+the second, not the first. The correct statement:
+
+| | binds on | number | rational method |
+|---|---|--:|---|
+| FLIPHEX 5×5 | game-tree complexity | ~10⁶¹, and ~10³⁰·⁵ even at the Knuth–Moore minimal tree `b^⌈d/2⌉ + b^⌊d/2⌋ − 1` | none — out of reach |
+| FLIPHEX 4×4 (adr-009 deck) | state count | 9.3 × 10¹⁰ states, against a tree of ~10³³ | **enumerate, do not search** |
+
+What makes checkers tractable is not a small state space but **convergence**:
+captures are irreversible, so play funnels into a small endgame family that
+retrograde analysis closes once, and the forward proof only has to *reach* it.
+FLIPHEX has no analogue. The layer profile is a **hump** — it peaks at `t = 15`
+filled cells (1.09 × 10¹⁷, 22 % of all states) and collapses to 3.36 × 10⁷ at
+`t = 25` — and because `k` empty cells is rigidly equivalent to ply `25 − k`,
+there is no *early* convergence to exploit: playing well cannot reach the narrow
+region sooner. That, not the state count, is why the 5×5 is not solvable here.
+
+**2. The move-ordering consequence must be split in two.** The Negative bullet
+"move ordering quality drives everything" is true of one part of the Decision and
+false of another:
+
+- **Decision part 2 (depth-limited 5×5 alpha-beta):** unchanged. Ordering is
+  where nearly all the speed lives (R&N §6.2.4), and iterative deepening survives
+  precisely as the ordering engine.
+- **Decision part 1 (the 4×4 exact solve):** ordering is **irrelevant**. The 4×4
+  tree is ~10²² times larger than the 4×4 state table, so perfect ordering still
+  leaves ~10¹⁶·⁵ nodes at the Knuth–Moore limit while the whole state space fits
+  in ~10¹¹ entries. **The 4×4 is not a search problem, it is an enumeration
+  problem.** Its binding resources are storage and enumeration throughput, and
+  effort spent on ordering heuristics there is wasted.
+
+**3. The pn-search argument in Amendment 1 was wrong; the alternative is reopened
+in narrower form.** Amendment 1 (Phase 2, 2026-07-31) argued that proof-number
+search "shines on sudden-death goal-proving … FLIPHEX has no such goal to prove,
+so pn-search loses its structural edge here." That inference does not hold.
+PN-search is a best-first method for **binary AND/OR trees with irregular
+branching**; its edge comes from expanding the most-proving node, i.e. from tree
+*shape*, not from goal type. Schaeffer's proof has no sudden-death goal either —
+the target value is a draw reached by piece reduction — and the proof-tree manager
+uses **Df-pn / proof-number search** anyway. FLIPHEX has both properties
+PN-search needs: a binary question (no draws, so one search rather than the two a
+three-valued game requires) and a wildly non-uniform tree.
+
+What actually parks PN-search here is narrower and survives the correction:
+FLIPHEX's exact solve is an **enumeration, and an enumeration has no scheduling
+problem**. Schaeffer needed a manager because his proof was a forward search over
+sub-problems that had to be *chosen*; the 4×4 sweep visits every layer
+unconditionally in a fixed order. So PN-search is reopened as a **scheduler for a
+forward proof**, not as a second search paradigm, and it becomes relevant only if
+a forward proof is ever attempted — which per (1) it will not be. Parked, for the
+right reason.
+
+**4. "Draws are impossible" is a trade, recorded here so it is not rediscovered.**
+It **buys** a backward pass with no cycles, no fixpoint iteration and no
+graph-history-interaction problem: values propagate in a single stratified sweep
+from ply 25 downward. It **costs** the forward proof's main economy — on a
+two-element value set a bound *is* the value, so Schaeffer's "partially proven"
+category is empty by construction and no branch can be cheaply discharged as
+irrelevant. The trade is heavily positive for FLIPHEX only because the cost lands
+entirely in a regime this ADR never enters: the 4×4 is an enumeration with no
+forward proof, and the 5×5 is out of reach on branching regardless.
+
+**5. Zobrist word count corrected.** The Decision says "50 random words". Keying
+on `(cell, colour)` and `(player, tile)` gives 25 × 2 + 2 × 13 = **76**.
+
+**6. Cross-axis rule (new, and previously unstated).** The Alternatives section
+rejects MCTS as the Axis-1 method "on principle: … using it for Axis 1 would
+destroy the independence that makes cross-axis verification meaningful." The
+principle is right but "independence" is the wrong word, and the imprecision
+hides where the rule actually bites. Correctness is untouched: alpha-beta returns
+the same value under any ordering, and retrograde enumeration has no ordering to
+corrupt. What is damaged is independence of **error**, via a specific mechanism —
+a solver whose order is seeded by the learner finishes fastest exactly on the
+lines the learner already plays well, so if the Axis-1 run then stops on a budget,
+the resolved positions are a biased sample over-representing the region where
+agreement was structurally guaranteed. That is **selection bias**, and it exists
+only when the Axis-1 run is *incomplete*. Hence three clauses, implementable as
+two metadata fields and a filter:
+
+> **R1.** Any Axis-1 result cited as ground truth for H1, H2 or H3 must come from
+> a run that terminated by **exhaustion**, not by a budget. Exhausted runs are
+> order-invariant, so Axis-2 seeding of their order is harmless by construction
+> and needs no prohibition.
+>
+> **R2.** Any Axis-1 run terminating on a budget — the depth-limited 5×5 agent, a
+> partial endgame database, a capped proof — uses **Axis-1-internal ordering
+> only** (iterative deepening, TT move, killer/history), and carries that
+> restriction as a recorded property of the artefact.
+>
+> **R3.** Every Axis-1 artefact records `ordering: internal | az-seeded` and
+> `termination: exhausted | budget`. H3's comparison set is the artefacts
+> satisfying R1, and the filter is applied *before* any comparison is computed.
+
+Scoping to *proof-producing* runs rather than to Axis 1 as a whole is deliberate:
+a blanket ban would forbid the depth-limited 5×5 agent from using a learned
+policy for move ordering, where nearly all its speed lives, and that agent is a
+**player, not a proof** — nothing it produces enters H3. The general form, which
+[adr-005](adr-005-alphazero-scope-and-network.md) applies in the other direction:
+*neither axis may be used to select or terminate the other along the dimension on
+which they are later compared.* For the 4×4 the rule is **vacuous today** —
+enumeration has no ordering degrees of freedom — which is the best possible time
+to adopt it.
+
+**Alternative added — meet-in-the-middle enumeration.** Enumerate forward from
+ply 0 and backward from ply 25 and meet at layer ~12. **Rejected**, and the layer
+profile is the reason: the middle of FLIPHEX is the *widest* part of the state
+space (the hump peaks at `t = 15`), so "meeting in the middle" means materialising
+the single largest layer in the game — 1.09 × 10¹⁷ positions on the 5×5. The
+technique pays off when the profile is a funnel; against a hump it is the worst
+available meeting point.
+
 ## Related
 
 - [adr-003](adr-003-piece-representation.md) — the state space this rests on
 - [adr-005](adr-005-alphazero-scope-and-network.md) — the axis this is compared against
 - [adr-008](adr-008-board-mirror-symmetry.md) — the mirror the endgame DBs can fold on
 - [adr-009](adr-009-reduced-deck-policy.md) — the reduced-deck policy this defers to
+- [adr-010](adr-010-solver-correctness.md) — how the results of this ADR are defended
 - `docs/research.md` — H1, H2, H3
+- `notes/phase2-synthesis.md` — S4, S6 (the readings behind the 2026-08-05 amendment)

--- a/docs/adr/adr-004-solver-approach.md
+++ b/docs/adr/adr-004-solver-approach.md
@@ -161,7 +161,9 @@ hand.
 still undefined — *which* tiles a reduced board draws. That choice swings the
 4×4 bound by ~3 orders of magnitude (table above) and decides whether a reduced
 solve is a faithful shrink of FLIPHEX. Pinned in
-[adr-009](adr-009-reduced-deck-policy.md) (Proposed).
+[adr-009](adr-009-reduced-deck-policy.md) (Accepted): keep `P6` + `P3-y`, fill by
+ascending arrow count; reduced boards are a purely computational device
+(OPEN-3 resolved), so faithfulness is judged against the shipped 5×5.
 
 ## Related
 

--- a/docs/adr/adr-004-solver-approach.md
+++ b/docs/adr/adr-004-solver-approach.md
@@ -130,9 +130,17 @@ Computing the reachable bound (the adr-003 formula) across board sizes:
 
 | Board | cells | full 13-deck | reduced deck |
 |---|--:|--:|--:|
-| 3×3 | 9 | 3.1 × 10⁹ | 7.1 × 10⁵ |
-| 4×4 | 16 | 8.3 × 10¹³ | 9.3 × 10¹⁰ |
+| 3×3 | 9 | 2.3 × 10⁹ | 7.1 × 10⁵ |
+| 4×4 | 16 | 4.8 × 10¹³ | 9.3 × 10¹⁰ |
 | 5×5 (shipped) | 25 | — | 4.9 × 10¹⁷ |
+
+> **Erratum (2026-08-05).** The two full-deck figures originally read 3.1 × 10⁹
+> and 8.3 × 10¹³. Both were computed with *both* hands at 13 tiles; the rules give
+> Player 1 thirteen (deck + joker) and Player 2 twelve
+> ([rules-canonical.md](../rules-canonical.md) §2), which is the convention the
+> 5×5 row already used. Recomputed with 13/12 by `scripts/layer_profile.py`. The
+> reduced-deck column is unaffected — adr-009 gives both players an identical
+> deck — so no conclusion below changes.
 
 The full-enumeration frontier sits at **N ≈ 13–15** (≈10¹²–10¹³). This sharpens
 part 1 of the Decision ("solve 3×3, attempt 4×4"):
@@ -143,7 +151,7 @@ part 1 of the Decision ("solve 3×3, attempt 4×4"):
   claimed to reveal 5×5 strategy, and the writeup must not imply otherwise.
 - **4×4 is promoted from "attempt" to the primary exact-solve target for
   strategic claims.** 16 cells give room for spatial/tempo tactics, and
-  8.3 × 10¹³ (full deck) — or 9.3 × 10¹⁰ with a reduced deck, ~3 orders of
+  4.8 × 10¹³ (full deck) — or 9.3 × 10¹⁰ with a reduced deck, ~3 orders of
   magnitude cheaper — is within reach of retrograde analysis on modern storage.
   3×3 stays the fast calibration solve; 4×4 carries the H1/H2 exact verdicts.
 

--- a/docs/adr/adr-005-alphazero-scope-and-network.md
+++ b/docs/adr/adr-005-alphazero-scope-and-network.md
@@ -53,8 +53,11 @@ the training target `z` is always exactly `±1`.
 sets ([adr-001](adr-001-perfect-information-scope.md)). Dirichlet noise at the
 root, temperature 1 for the opening plies then greedy.
 
-**No symmetry augmentation.** The board's symmetry group is trivial (adr-002),
-so unlike Go's 8× or Connect Four's 2×, there is none to exploit.
+~~**No symmetry augmentation.** The board's symmetry group is trivial (adr-002),
+so unlike Go's 8× or Connect Four's 2×, there is none to exploit.~~
+**Decision unchanged, justification superseded** — see the Phase 2 amendment
+below and [adr-008](adr-008-board-mirror-symmetry.md). The board *does* have a
+Z/2 mirror; augmentation is still rejected, on measured grounds.
 
 ## Consequences
 
@@ -114,8 +117,79 @@ material.
 **AlphaZero-style with a learned model (MuZero).** Out of scope. The rules are
 known and cheap to simulate; there is nothing to gain.
 
+## Amendment — Phase 2 (2026-08-05): symmetry justification, the evaluator gate, and two guard rails
+
+Reading R&N Ch.6, Silver 2017/2018 and Schaeffer 2007 produced four refinements.
+None changes the network; one corrects a false premise, two add decisions the
+original ADR left implicit, and one closes a methodological trap.
+
+**1. The "no augmentation" justification was wrong; the decision survives.** The
+board's symmetry group is **not** trivial — it is Z/2, a left-right mirror across
+column C ([adr-008](adr-008-board-mirror-symmetry.md)). The struck bullet above
+is replaced by:
+
+> **No symmetry augmentation.** The board has a Z/2 mirror, but the chiral
+> `P3-y` tile makes it a *partial* game symmetry: the mirror of a legal move need
+> not be legal, so `M(s)` may not be augmented while either copy of `P3-y` is in
+> a hand. Every tile is played (rules-canonical §2, I3/I5), so the condition is
+> always reached — but late: under a uniform-random play order the second `P3-y`
+> lands on ply 17.2 on average, leaving ≈**31 %** of plies augmentable. The
+> available gain is therefore ≈**1.31×** in data, against a per-sample validity
+> check and the risk that a wrong check silently trains the policy toward a move
+> that does not exist. Not worth it.
+
+Verified by `scripts/check_mirror_game_symmetry.py`: 150 of the 1450 opening
+moves have no legal mirror image, all of them `P3-y`; the mirror becomes a full
+game symmetry exactly once both copies are placed and inert.
+
+**2. The evaluator gate is RETAINED, with an explicit game budget.** AlphaGo Zero
+promotes a challenger only at ≥55 % over 400 games; AlphaZero drops the gate.
+That removal is **bundled** with several other changes (single continuously
+updated network, self-play from the current rather than the best network, reused
+hyper-parameters) and no experiment in either paper isolates it — so the
+published evidence is "a system without the gate works", not "the gate is
+unnecessary". AlphaZero's replacement is a large replay buffer plus small
+continuous updates, which damps regressions by construction but was never
+measured. On a single laptop, where a collapsed run costs days and there is no
+external benchmark for an original game, the discrete measured guard is worth its
+compute.
+
+The budget is not optional. At n = 400 evaluation games, two equal networks clear
+55 % about 2 % of the time; at n = 100 they clear it **16 %** — a gate promoting
+noise one time in six is worse than no gate, because it also manufactures
+confidence. Adopt **400 games at 55 %**, or an explicit relaxation (gate every
+`k` generations, or a lower threshold with its false-promotion rate stated).
+Removing the gate is a Phase 4 optimisation to be justified by measurement, never
+inherited from AlphaZero by default.
+
+**3. Plain UCT with random playouts is the Axis-2 baseline.** AlphaZero makes two
+substitutions and they have different standing for FLIPHEX. Replacing UCB1 with
+PUCT is **required**: `√(ln N / n(a))` is infinite at `n(a) = 0`, so prior-free
+selection must visit all 1450 opening children before it distinguishes any of
+them, and UCB1's distribution-free regret guarantee needs far more simulations
+than a laptop will run. Dropping rollouts is **inherited, not forced**: FLIPHEX
+playouts are ≤25 plies, always terminate and always yield a decided winner, so
+R&N §6.4's early-playout-termination machinery is void. Plain UCT is therefore
+cheap to build and gives an absolute floor that depends on no trained network.
+The learned agent must beat it before any result is reported.
+
+**4. Checkpoint selection may not read Axis 1.** Scoring candidate networks
+against the exact 4×4 database is tempting — near-zero compute, an objective
+yardstick where none otherwise exists — and it is **circular**: selecting
+networks by agreement with the solver and then reporting agreement with the
+solver as H3's evidence optimises the metric directly. Solver positions may be
+logged, plotted and watched as a *reported diagnostic*; no promotion,
+early-stopping or checkpoint-selection decision may read them. This is the mirror
+image of the rule [adr-004](adr-004-solver-approach.md) adopts for the other
+direction, and the general form is stated there: *neither axis may be used to
+select or terminate the other along the dimension on which they are later
+compared.*
+
 ## Related
 
 - [adr-003](adr-003-piece-representation.md) — why no orientation planes
 - [adr-004](adr-004-solver-approach.md) — the ground truth this is compared against
+- [adr-008](adr-008-board-mirror-symmetry.md) — the mirror that does *not* fund augmentation
+- [adr-010](adr-010-solver-correctness.md) — the verification the diagnostic in (4) reads from
 - `docs/research.md` — H3, H5
+- `notes/phase2-synthesis.md` — S1, S2, S3 (the readings behind the amendment)

--- a/docs/adr/adr-008-board-mirror-symmetry.md
+++ b/docs/adr/adr-008-board-mirror-symmetry.md
@@ -1,0 +1,127 @@
+# ADR-008 — The board has a mirror symmetry (Z/2), not a trivial group
+
+**Status:** Accepted (Phase 2)
+**Date:** 2026-07-29
+**Deciders:** Bruno Ramos Martins (co-designer)
+**Amends:** the "trivial symmetry group" claim in
+[board-geometry.md](../board-geometry.md).
+
+## Context
+
+Phase 0 concluded that the board has a **trivial symmetry group**. The argument
+in `board-geometry.md` is: columns A, C, E sit at vertical offsets 0..4 while B
+and D sit at 0.5..4.5, so the two sets have different vertical centres and "no
+rotation or reflection maps the cell set onto itself." This was used to justify
+three downstream claims: no data augmentation for Axis 2, no transposition-table
+canonicalisation for Axis 1, and that H1 (first-player advantage) must be settled
+computationally because there is no strategy-stealing argument.
+
+Studying **AlphaZero (Silver 2018)** put pressure on this. AlphaZero *drops*
+symmetry augmentation precisely because chess and shogi are asymmetric, and was
+read as the closer template for FLIPHEX. That prompted a direct check of
+FLIPHEX's symmetry rather than trusting the Phase 0 prose.
+
+## Decision
+
+Adopt the computed result: the automorphism group of the board — as a **directed
+hex graph** (adjacency *and* the six arrow directions the flip rule consumes) —
+is **Z/2**. Its non-trivial element is a **left-right mirror across column C**:
+
+- Cells: `A ↔ E`, `B ↔ D`, column `C` fixed (same row throughout).
+- Directions: `N → N`, `S → S`, `NE ↔ NW`, `SE ↔ SW`.
+- **180° rotation is _not_ a symmetry** (columns B and D are staggered half a
+  cell, so a half-turn lands them off the grid; and 25 is odd, so any involution
+  must fix a cell — the mirror fixes column C, a rotation would fix none).
+
+Computed by `scripts/check_symmetry.py` (brute force over the 12 dihedral
+direction actions × all cell permutations), pinned by `tests/test_symmetry.py`,
+and confirmed to hold on the 3×3 reduced variant as well.
+
+### Why the Phase 0 argument was wrong
+
+The "different vertical centres" observation is true but does not imply
+triviality. The mirror maps A↔E and C↔C **within** the offset-0 group and B↔D
+**within** the offset-0.5 group — it never equates an offset-0 column with an
+offset-0.5 one, so the differing centres are irrelevant to it. The Phase 0 prose
+only ruled out symmetries that *mix* the two groups (90° rotation, top-bottom
+mirror, 180°), which do indeed fail.
+
+The doc's own degree evidence in fact **contains** the mirror: it names `A1` and
+`E1` as the two degree-2 cells and then claims they "have no degree-2 partners" —
+but the mirror makes them each other's image. `C1` (deg 3) and `C5` (deg 5) lie
+on the mirror axis and are fixed points, so they need no partner.
+
+## Scope — board symmetry vs. game symmetry (the chiral-tile obstruction)
+
+This is a symmetry of the **board geometry and the flip rule**, not automatically
+of the game *dynamics*. The mirror reflects arrow patterns, and the deck is closed
+under reflection **except** the single chiral piece `P3-y`, whose mirror is a
+distinct pattern **no player holds**. Mirroring a move that places `P3-y` would
+require a tile with the reflected arrow pattern, which is in neither hand, so the
+mirrored move cannot reproduce the mirrored outcome. (Checked by hand: `P3-y` =
+arrow slots {0,1,3}; its reflection {0,3,5} is not a rotation of {0,1,3}.)
+
+- **Board-level automorphism: Z/2 — confirmed, unconditional.**
+- **Game-level (dynamics) symmetry: broken while a `P3-y` remains in either
+  hand.** Once *both* `P3-y` tiles are placed they are inert (adr-003), the
+  obstruction vanishes, and the mirror *is* a symmetry of the remaining sub-game.
+  So the usable symmetry is **partial — restricted to states with no `P3-y` in
+  hand.**
+
+**Relation to OPEN-2 (RESOLVED 2026-07-29).** The two decks' `P3-y` tiles are
+*identical* (same manufacturing mould, same chirality), **not** mirror images.
+This settles **seat equivalence** — both players hold `(0,1,3)` on their own face
+— so there is **no deck confound for H1**. It does *not* grant the mirror
+augmentation: the obstruction is the mere *existence* of a chiral tile,
+independent of how the two decks relate. (A colour-swapping mirror
+τ = mirror ∘ swap-colours would need *mirrored* decks, which these are not, and
+would be broken anyway by the joker / first-move asymmetry.) An earlier draft of
+this ADR wrongly tied the augmentation to OPEN-2; corrected here.
+
+## Consequences
+
+**Positive — but partial (endgame-restricted)**
+
+- **Mirror-canonical transposition keys** for Axis 1 and MCTS, valid on states
+  where neither player still holds `P3-y` (both already placed). Useful for
+  endgame databases and late-game search, not the whole tree.
+- **Data augmentation** for Axis 2 is valid on that same sub-space only — *not* a
+  clean whole-game 2×, since the chiral tile blocks it earlier. Treat any mirror
+  augmentation as an ablation to measure, not a free win.
+- Applies to the 3×3/4×4 reduced variants (same Z/2, same chiral-tile caveat).
+
+**Unchanged — H1 still needs computation**
+
+- The mirror **preserves the player to move**; it is *not* a colour/player swap.
+  So it yields **no strategy-stealing or pairing argument for H1**. The Phase 0
+  *conclusion* about H1 stands — only its stated *premise* ("no symmetry") was
+  wrong. H1 must still be settled by the solver and self-play.
+
+**Documentation edits (applied)**
+
+- `board-geometry.md` is **generated**: the §symmetry prose was corrected in
+  `scripts/build_docs.py` and the file regenerated; the generated file is not
+  hand-edited.
+- The augmentation opportunity should be noted in
+  [adr-005](adr-005-alphazero-scope-and-network.md) and the canonicalisation
+  opportunity in [adr-004](adr-004-solver-approach.md) when those axes begin.
+
+## Alternatives considered
+
+- **Keep "trivial symmetry group."** Rejected: it is computationally false
+  (`|Aut| = 2`), and the doc's own degree data exhibits the counterexample.
+- **Claim the full 2× game augmentation now.** Rejected: premature. The
+  game-level symmetry is conditional on OPEN-2; only the board-level symmetry is
+  unconditional today.
+
+## Related
+
+- `scripts/check_symmetry.py`, `tests/test_symmetry.py` — the computation and its
+  regression test.
+- **OPEN-2** in [rules-canonical.md](../rules-canonical.md) — the chiral tile that
+  decides whether the game inherits the board's mirror.
+- [board-geometry.md](../board-geometry.md) — the amended claim.
+- [adr-004](adr-004-solver-approach.md) (canonicalisation),
+  [adr-005](adr-005-alphazero-scope-and-network.md) (augmentation).
+- [notes/silver-2018-alphazero.md](../../notes/silver-2018-alphazero.md) §1.2/§3.1
+  — the reading that prompted the check.

--- a/docs/adr/adr-009-reduced-deck-policy.md
+++ b/docs/adr/adr-009-reduced-deck-policy.md
@@ -1,0 +1,110 @@
+# ADR-009 — Reduced-deck policy for small board variants
+
+**Status:** Proposed
+**Date:** 2026-07-31
+**Deciders:** Bruno Ramos Martins
+**Needs:** author ratification; ideally a check against the physical game (see
+OPEN-3).
+
+## Context
+
+[adr-004](adr-004-solver-approach.md) parameterises the board as
+`(n_columns, cells_per_column, deck)` and calls for "proportionally smaller
+decks" on the 3×3 and 4×4 variants, but never says **which** tiles a reduced
+board draws. That gap is load-bearing:
+
+- **It decides solvability.** The Phase 2 complexity sweep shows the reduced-deck
+  size swings the state-space bound by ~3 orders of magnitude — for 4×4,
+  8.3 × 10¹³ with the full 13-piece deck versus 9.3 × 10¹⁰ with a minimal deck.
+  One is borderline; the other is comfortably enumerable.
+- **It decides meaning.** A badly chosen reduced deck makes the *exact solve*
+  validate a game that is not a faithful shrink of FLIPHEX. Since the exact
+  solve is the project's strongest claim (H1/H2 on a real FLIPHEX-family game),
+  the deck must be principled, not incidental.
+
+The tension is real. The full 12-archetype deck is a **theorem** — the complete
+set of binary bracelets of length 6 ([adr-003](adr-003-piece-representation.md),
+[piece-archetypes.md](../piece-archetypes.md)). Any strict subset loses that
+completeness, so no reduced deck is a "faithful" shrink in the strong sense.
+Faithfulness becomes a judgment call — which is exactly why it needs an ADR.
+
+The 13 pieces per player, in ascending arrow count:
+
+`joker`(0) · `P1`(1) · `P2-adj` `P2-skip` `P2-opp`(2) · `P3-fan` `P3-y` `P3-tri`(3)
+· `P4-adj` `P4-skip` `P4-opp`(4) · `P5`(5) · `P6`(6).
+
+## Decision (proposed)
+
+For a board with capacity `a = ⌈N/2⌉` placements for the first player, the
+**default reduced deck** is the `a`-tile set chosen by this priority:
+
+1. **Always include `P6` and `P3-y`.** These two carry the dynamics the study
+   exists to probe: `P6` is the maximum-flip tile (all six arrows — the largest
+   possible swing), and `P3-y` is the sole **chiral** tile — the piece whose
+   reflection leaves the deck and thereby breaks the board's Z/2 mirror at the
+   game level ([adr-008](adr-008-board-mirror-symmetry.md)). A reduced game that
+   keeps both still exercises the flip mechanic *and* the H1/mirror question.
+2. **Fill the remaining `a − 2` slots by ascending arrow count** from the tiles
+   not yet chosen (`P1`, then the 2-arrow group, then the rest). This spans the
+   low-to-high "power" range instead of clustering at one flip strength.
+3. **The joker is included only when H2 (the joker hypothesis) is under test on
+   that variant.** Otherwise it is left out, keeping the reduced deck purely
+   archetypal.
+
+Worked examples:
+
+- **3×3** (`a = 5`): `{P6, P3-y, P1, P2-adj, P2-skip}` (+ joker if testing H2).
+- **4×4** (`a = 8`): `{P6, P3-y, P1, P2-adj, P2-skip, P2-opp, P3-fan, P3-tri}`.
+
+Both players draw from an identical reduced deck, consistent with the
+`OPEN-2`-resolved finding that the two physical decks are the same (no chiral
+seat confound).
+
+## Consequences
+
+**Positive**
+
+- The 4×4 exact solve lands near 9 × 10¹⁰ states, comfortably enumerable, so
+  H1/H2 get an exact verdict on a *strategically non-trivial* board — a stronger
+  result than 3×3 alone.
+- Every reduced variant keeps the two most dynamically interesting tiles, so the
+  solve speaks to the same questions as the full game rather than a toy.
+
+**Negative / accepted costs**
+
+- This is a **modeling choice, not a faithful shrink** — the reduced deck is not
+  a complete bracelet enumeration, so results transfer to the full 5×5 as
+  *evidence*, not proof. The writeup must state the deck explicitly with every
+  reduced-board result.
+- Ascending-arrow fill is a defensible default, not the only one; a different
+  fill could change fine-grained tactics on very small boards.
+
+## Alternatives considered
+
+- **Full 13-deck, unused pieces.** Most faithful to "same deck, smaller board",
+  and needs no selection rule — but ~3 orders of magnitude more expensive
+  (4×4 → 8.3 × 10¹³, borderline) and it lets the player choose among tiles that
+  will never fit, which is arguably *less* faithful to the tempo of a small game.
+- **Random subset per seed.** Tests robustness to deck composition, but muddies
+  interpretation of any single solve. Better as a *stretch* robustness check on
+  top of the fixed default than as the default itself.
+- **Arrow-count-balanced subset** (one of each count as far as possible).
+  Reasonable, but does not guarantee `P6`/`P3-y` on the smallest boards, which
+  are the two tiles the study most wants present.
+
+## Open question
+
+**OPEN-3.** Is a reduced FLIPHEX board something the physical game supports at
+all, or is it a purely **computational device**? If purely computational, then
+faithfulness is judged against the shipped 5×5, not a physical artifact, and this
+ADR is entirely a modeling decision. If the physical set implies a natural
+reduced deck (e.g. a printed 3×3 teaching variant), that should override the
+default here. To be checked with the game's author before Phase 3 locks the
+solver's variant list.
+
+## Related
+
+- [adr-003](adr-003-piece-representation.md) — the deck-as-theorem and the state bound
+- [adr-004](adr-004-solver-approach.md) — the solver that consumes this deck
+- [adr-008](adr-008-board-mirror-symmetry.md) — why `P3-y` is kept in every variant
+- `docs/research.md` — H1, H2, and the (optional) counterfactual H6

--- a/docs/adr/adr-009-reduced-deck-policy.md
+++ b/docs/adr/adr-009-reduced-deck-policy.md
@@ -13,7 +13,7 @@ board draws. That gap is load-bearing:
 
 - **It decides solvability.** The Phase 2 complexity sweep shows the reduced-deck
   size swings the state-space bound by ~3 orders of magnitude — for 4×4,
-  8.3 × 10¹³ with the full 13-piece deck versus 9.3 × 10¹⁰ with a minimal deck.
+  4.8 × 10¹³ with the full deck versus 9.3 × 10¹⁰ with a minimal deck.
   One is borderline; the other is comfortably enumerable.
 - **It decides meaning.** A badly chosen reduced deck makes the *exact solve*
   validate a game that is not a faithful shrink of FLIPHEX. Since the exact
@@ -81,7 +81,7 @@ seat confound).
 
 - **Full 13-deck, unused pieces.** Most faithful to "same deck, smaller board",
   and needs no selection rule — but ~3 orders of magnitude more expensive
-  (4×4 → 8.3 × 10¹³, borderline) and it lets the player choose among tiles that
+  (4×4 → 4.8 × 10¹³, borderline) and it lets the player choose among tiles that
   will never fit, which is arguably *less* faithful to the tempo of a small game.
 - **Random subset per seed.** Tests robustness to deck composition, but muddies
   interpretation of any single solve. Better as a *stretch* robustness check on

--- a/docs/adr/adr-009-reduced-deck-policy.md
+++ b/docs/adr/adr-009-reduced-deck-policy.md
@@ -1,10 +1,8 @@
 # ADR-009 — Reduced-deck policy for small board variants
 
-**Status:** Proposed
-**Date:** 2026-07-31
+**Status:** Accepted
+**Date:** 2026-07-31 (ratified 2026-07-31)
 **Deciders:** Bruno Ramos Martins
-**Needs:** author ratification; ideally a check against the physical game (see
-OPEN-3).
 
 ## Context
 
@@ -92,15 +90,21 @@ seat confound).
   Reasonable, but does not guarantee `P6`/`P3-y` on the smallest boards, which
   are the two tiles the study most wants present.
 
-## Open question
+## OPEN-3 — RESOLVED (2026-07-31): reduced boards are a purely computational device
 
-**OPEN-3.** Is a reduced FLIPHEX board something the physical game supports at
-all, or is it a purely **computational device**? If purely computational, then
-faithfulness is judged against the shipped 5×5, not a physical artifact, and this
-ADR is entirely a modeling decision. If the physical set implies a natural
-reduced deck (e.g. a printed 3×3 teaching variant), that should override the
-default here. To be checked with the game's author before Phase 3 locks the
-solver's variant list.
+The game's author confirms that reduced FLIPHEX boards have **no physical
+counterpart** — they exist only as a computational instrument for exact solving.
+Consequences:
+
+- **Faithfulness is judged against the shipped 5×5**, not against any physical
+  artifact. This ADR is therefore entirely a modeling decision, and the default
+  above stands without needing to match a printed variant.
+- There is no external constraint on the reduced deck, so the `P6` + `P3-y`
+  anchor and the ascending-arrow fill are free to optimise for *what the study
+  wants to observe* (max-flip dynamics and the chiral/mirror question) rather
+  than for physical fidelity.
+- Any reduced-board result must be reported as evidence *about the 5×5 design*,
+  carrying its board size and deck explicitly — never as a game in its own right.
 
 ## Related
 

--- a/docs/adr/adr-010-solver-correctness.md
+++ b/docs/adr/adr-010-solver-correctness.md
@@ -80,7 +80,7 @@ This is asserted at every write, not sampled: it is the cheapest possible check
 and it is total.
 
 **V3 — two independent methods must agree on the full 3×3.** The 3×3 variant
-(3.1 × 10⁹ full deck, 7.1 × 10⁵ reduced) is solved twice, by **fundamentally
+(2.3 × 10⁹ full deck, 7.1 × 10⁵ reduced) is solved twice, by **fundamentally
 different** methods — forward alpha-beta with no database, and retrograde
 enumeration — and the game-theoretic value of every position must match. This is
 the FLIPHEX analogue of Schaeffer's architectural redundancy, whose real form is

--- a/docs/adr/adr-010-solver-correctness.md
+++ b/docs/adr/adr-010-solver-correctness.md
@@ -1,0 +1,190 @@
+# ADR-010 — Solver correctness: verification as an architectural concern
+
+**Status:** Accepted (Phase 2)
+**Date:** 2026-08-05
+**Deciders:** Bruno Ramos Martins
+
+## Context
+
+[adr-004](adr-004-solver-approach.md) commits Axis 1 to producing **ground
+truth**: exact game values that H1, H2 and H3 rest on. It says nothing about how
+those values are defended.
+
+That gap is the whole risk. The 4×4 exact solve is a ~9.3 × 10¹⁰-state
+enumeration ([adr-009](adr-009-reduced-deck-policy.md) deck) whose visible output
+is a *single verdict* — "the first player wins" or "the second player wins".
+Nobody can eyeball 10¹¹ entries, and the characteristic failure mode is not a
+crash but a **plausible wrong answer**: an off-by-one in the layer sweep, a
+Zobrist collision, a misapplied flip at a board edge, a truncated write. All of
+these terminate normally and produce a verdict that looks exactly like a correct
+one.
+
+Schaeffer (2007) §5 is the precedent and it is deliberately modest. The paper
+lists anticipated sources of error (*"algorithm bugs and data transmission
+errors"*), *"verifying all computation results and doing consistency checks"*,
+and notes that *"some of the computations have been independently verified"* —
+only *some*, and §7 concedes that *"although important components of the checkers
+proof have been independently verified, there may be skeptics."* If a Science
+paper backed by 18 years and ~50 machines writes that sentence, the calibration
+for a solo laptop project is set: correctness is established by **converging
+independent evidence**, never by a run that finished.
+
+FLIPHEX has two structural advantages checkers did not, and both are cheap enough
+that declining to use them would be indefensible: a terminal layer that is small
+and decidable **in closed form**, and a per-layer state count that is known **in
+closed form** ([adr-003](adr-003-piece-representation.md)).
+
+## Decision
+
+The FLIPHEX solver treats correctness as an explicit architectural concern rather
+than an implementation detail. **No computed database or game-theoretic result is
+accepted solely on the basis of successful execution.** Correctness is
+established through independent verification, global invariant checking,
+integrity verification of stored data, and cross-validation against an
+independently implemented reference solver on tractable subproblems. A result is
+valid only if **all** applicable verification mechanisms agree; any disagreement
+invalidates the run rather than being reconciled after the fact.
+
+Six mechanisms, in the order they must pass. `V0` and `V1` are mandatory for
+every solve; `V2`–`V4` are mandatory for any result cited in `research.md`; `V5`
+is mandatory for any database written to disk.
+
+**V0 — closed-form verification of the terminal layer.** Every position with the
+board full is decided by *counting cells*: no search, no recursion, no
+recurrence. The layer is small — 2¹⁶ = **65 536** positions on the 4×4 with the
+default adr-009 deck, and 2²⁵ = **3.36 × 10⁷** on the 5×5. In both cases every
+tile has been played, so the hand dimension collapses to a single point; a
+joker-bearing variant multiplies the count by the leftover-tile choices and is
+still trivially enumerable. The entire base case of the retrograde pass is
+therefore checked exhaustively, in seconds, **against a definition rather than
+against another implementation**. This is verification zero because a bug in the
+base case silently poisons every layer above it, and no later check would
+distinguish it from a genuine result.
+
+**V1 — per-layer state counts against the combinatorial formula.** The number of
+positions in layer `t` is known in closed form,
+`C(N,t) · 2^t · C(d₁,⌈t/2⌉) · C(d₂,⌊t/2⌋)`, for a board of `N` cells and hands
+of `d₁`, `d₂`. The enumerator's actual per-layer output is counted and compared.
+This is the FLIPHEX analogue of chess's `perft`, and it catches the most likely
+bug class — a generator that drops or duplicates positions — which every
+value-level check would otherwise pass. The same run **doubles as the
+reachability measurement**: the gap between the formula (which counts
+configurations) and the enumeration (which counts positions actually reachable by
+legal play) is a quantity `research.md` currently reports only as a bound.
+
+**V2 — the no-draw invariant, asserted as a theorem.** Cell counts are odd
+(25 on the 5×5, and any `N` used must be odd for the same reason), so a draw is
+arithmetically impossible ([adr-007](adr-007-flip-toggles-colour.md)). **Any draw
+value anywhere in the database is a proof of a bug**, not a position to inspect.
+This is asserted at every write, not sampled: it is the cheapest possible check
+and it is total.
+
+**V3 — two independent methods must agree on the full 3×3.** The 3×3 variant
+(3.1 × 10⁹ full deck, 7.1 × 10⁵ reduced) is solved twice, by **fundamentally
+different** methods — forward alpha-beta with no database, and retrograde
+enumeration — and the game-theoretic value of every position must match. This is
+the FLIPHEX analogue of Schaeffer's architectural redundancy, whose real form is
+worth stating precisely: his component 3 ran *"two different programs"* on the
+same position, *"thus increasing the chances of obtaining a useful result"*.
+[adr-004](adr-004-solver-approach.md) already designates the 3×3 as a correctness
+fixture rather than a strategy microcosm; this is what it is a fixture *for*.
+
+**V4 — random-sample re-derivation on the 4×4.** A random sample of solved 4×4
+positions is re-derived by direct forward search **without consulting the
+database**, and the values compared. Sample size and seed are recorded in
+`experiments/registry.md` with the run. This is the only check that exercises the
+4×4 value recurrence against something other than itself.
+
+**V5 — integrity of stored data.** Every database file carries a checksum,
+verified on load. This defends against the failure Schaeffer names explicitly
+(*data transmission errors*) and against the mundane version — a truncated write
+from a laptop that slept mid-run.
+
+**V6 — mirror consistency in the endgame databases (5×5 only).** Where the mirror
+is a valid game symmetry — both `P3-y` placed and inert, which is exactly the
+endgame region the databases cover ([adr-008](adr-008-board-mirror-symmetry.md))
+— the values of `s` and `M(s)` must be equal. This costs one permutation per
+sampled entry and tests the flip rule, the geometry table and the value recurrence
+simultaneously. Note it is a **check**, not only the ~2× compression adr-004's
+amendment claims: if the databases fold on the mirror, V6 must be run against an
+*unfolded* sample, or it verifies nothing.
+
+**Claim wording.** Verification determines what may be written, not only what may
+be believed. The strongest sentence a single implementation, run once, by one
+person, is entitled to:
+
+> An exhaustive retrograde enumeration of the 4×4 variant (deck per adr-009)
+> assigns the initial position the value *W*. The computation passed every
+> verification procedure in adr-010 — closed-form terminal-layer check, per-layer
+> state counts against the combinatorial formula, the no-draw invariant, and
+> agreement with an independent forward solver on the full 3×3 game and on a
+> random sample of 4×4 positions. **It has not been independently
+> reimplemented.**
+
+The final clause is what makes the rest credible and it costs nothing. It is
+also why `research.md`'s verdict column must carry an **evidence class** rather
+than a bare verdict.
+
+## Consequences
+
+**Positive**
+
+- The two closed-form checks (`V0`, `V1`) verify against *definitions*, not
+  against other code, which is a strictly stronger form of evidence than
+  cross-implementation agreement. Checkers had no comparable check; FLIPHEX gets
+  it because the board is small and the terminal condition is arithmetic.
+- `V1` produces the reachability measurement as a by-product, converting a number
+  `research.md` currently reports as a bound into a measured quantity.
+- `V3` gives the 3×3 solve a clear job. Without it the 3×3 is an underpowered
+  strategic result; with it, it is the reference implementation.
+- The claim wording is drafted **before** the result exists, so the verdict cannot
+  be talked up after seeing it.
+
+**Negative / accepted costs**
+
+- `V3` requires **two** solver implementations for the 3×3, one of which is
+  otherwise redundant. Accepted: it is the only mechanism here that would catch a
+  shared misunderstanding of the *rules* rather than of the code.
+- `V1` and `V2` run inside the enumeration hot loop. Both are O(1) per position
+  and the sweep is storage-bound rather than compute-bound
+  ([adr-004](adr-004-solver-approach.md) amendment), so the overhead is accepted
+  without measurement; if it ever binds, `V1` may be sampled but `V2` may not.
+- **Independent reimplementation is out of scope** for a solo project and is
+  therefore a permanent, disclosed gap. It is named in the claim wording rather
+  than hidden.
+
+**Neutral**
+
+- These mechanisms verify the *implementation*, never the *rules*. If
+  `docs/rules-canonical.md` misdescribes FLIPHEX, every check here passes and the
+  answer is still wrong. `OPEN-1` is the live instance.
+
+## Alternatives considered
+
+**Trust a single clean run.** The default, and the position the ADR exists to
+reject. A ~10¹¹-state enumeration has no observable surface: silent bugs produce
+plausible verdicts, so "it ran and gave an answer" is not evidence.
+
+**Formal verification of the solver.** Proving the value recurrence correct in a
+proof assistant. Rejected: it would verify the model, not the ~10¹¹ entries the
+implementation actually produced, which is where the risk lives. `V0`–`V6` target
+the failure modes that a proved-correct algorithm still suffers.
+
+**Independent reimplementation of the 4×4 solver.** The strongest available
+check and the one Schaeffer partially achieved. Rejected on cost for a solo
+project; `V3` retains the idea at 3×3 scale, where a second implementation is
+days rather than weeks, and the gap at 4×4 is disclosed.
+
+**Sampling `V2` rather than asserting it.** Rejected. The no-draw check is a
+single integer comparison and is the only *total* check available; degrading a
+total check to a sampled one to save nothing measurable is a bad trade.
+
+## Related
+
+- [adr-004](adr-004-solver-approach.md) — the solver whose results this defends
+- [adr-003](adr-003-piece-representation.md) — the closed-form state count `V1` uses
+- [adr-007](adr-007-flip-toggles-colour.md) — why draws are impossible (`V2`)
+- [adr-008](adr-008-board-mirror-symmetry.md) — the partial mirror `V6` exploits
+- [adr-009](adr-009-reduced-deck-policy.md) — the decks these solves use
+- `docs/research.md` — H1, H2, H3, and the evidence-class column
+- `notes/schaeffer-2007-checkers-is-solved.md` — §5.1, §5.2 (the reading behind this)

--- a/docs/board-geometry.md
+++ b/docs/board-geometry.md
@@ -118,20 +118,25 @@ direction `d` if and only if `Y` neighbours `X` in direction `d + 3`.
   is a candidate move-ordering signal for the Phase 3 solver.
 - The two degree-2 cells are `A1` and `E1`, the poorest cells on the board.
 
-### The board is not centrally symmetric — and that matters
+### The board has a single mirror symmetry — and that matters
 
 Columns A, C, E carry cells at vertical offsets 0..4 while B and D sit at
-0.5..4.5. Those two sets of columns have different vertical centres (2 and
-2.5), so no rotation or reflection maps the cell set onto itself: the board's
-symmetry group is **trivial**. The shape "leans". Concretely `C1` has degree 3
-while `C5` has degree 5, and `A1`/`E1` (degree 2) have no degree-2 partners
-under any candidate symmetry.
+0.5..4.5. Those two column groups have different vertical centres (2 and 2.5),
+so no symmetry can *mix* them — that rules out 90° rotation, a top-bottom
+mirror, and 180° rotation. But one symmetry survives *within* the groups: a
+**left-right mirror across column C** (`A`↔`E`, `B`↔`D`, `C` fixed; and
+`NE`↔`NW`, `SE`↔`SW`). The board's automorphism group is therefore **Z/2**, not
+trivial. Consistently, `A1` and `E1` — the two degree-2 cells — are each other's
+mirror image, and `C1`/`C5` lie on the axis and are fixed. Verified by
+`scripts/check_symmetry.py`; recorded in `docs/adr/adr-008-board-mirror-symmetry.md`.
 
-This is a real asymmetry in the physical artifact, not a modelling artifact,
-and it is directly relevant to **H1 (first-player advantage)**: on a board with
-no symmetry group, there is no strategy-stealing or pairing argument available,
-so H1 has to be settled computationally. Worth stating explicitly in the
-writeup — it is part of why the game is interesting.
+The mirror is a symmetry of the geometry and the flip rule; whether the *game*
+inherits it hinges on the chiral `P3-y` tile (`OPEN-2`). If it does, self-play
+gains a 2× data augmentation and transposition keys can be mirror-canonicalised.
+For **H1 (first-player advantage)** the mirror changes nothing: it preserves the
+player to move, so it is not a colour swap and gives no strategy-stealing or
+pairing argument. H1 must still be settled computationally — the conclusion the
+Phase 0 note reached, though its "no symmetry" premise was wrong.
 
 > **OPEN-1.** Confirm against the physical board that all five columns really
 > hold five cells and that no cell is missing from a corner. The poster

--- a/docs/research.md
+++ b/docs/research.md
@@ -109,8 +109,8 @@ full-enumeration frontier at **N ≈ 13–15 cells**:
 
 | Board | cells | reachable bound (full deck) |
 |---|--:|--:|
-| 3×3 | 9 | 3.1 × 10⁹ |
-| 4×4 | 16 | 8.3 × 10¹³ (9.3 × 10¹⁰ reduced deck) |
+| 3×3 | 9 | 2.3 × 10⁹ |
+| 4×4 | 16 | 4.8 × 10¹³ (9.3 × 10¹⁰ reduced deck) |
 | 5×5 | 25 | 4.9 × 10¹⁷ |
 
 So 3×3 is a *correctness fixture* (too cramped for tactics like deferring a flip

--- a/docs/research.md
+++ b/docs/research.md
@@ -118,7 +118,9 @@ to set up a later swing) and **4×4 is the strategically meaningful exact solve*
 carrying the H1/H2 verdicts. Recorded in the
 [adr-004 Phase 2 amendment](adr/adr-004-solver-approach.md). The reduced-deck
 choice that makes 4×4 tractable is pinned in
-[adr-009](adr/adr-009-reduced-deck-policy.md) (Proposed).
+[adr-009](adr/adr-009-reduced-deck-policy.md) (Accepted: keep `P6` + `P3-y`,
+fill by ascending arrow count; reduced boards are a purely computational
+device).
 
 ## Verdicts
 

--- a/docs/research.md
+++ b/docs/research.md
@@ -6,11 +6,24 @@ timestamps the pre-registration. Until then H1–H5 may be reworded, split, or
 dropped. After that tag, this file may only gain verdicts; anything else needs
 an ADR.
 
+## Thesis
+
+FLIPHEX is treated not only as a game to master but as a **design to understand**.
+Self-play reinforcement learning and exact search are used as *instruments* to
+characterise the properties of an original, previously un-analysed game — its
+first-player balance, the joker's effect, its board geometry, and its tile
+distribution — with strong play as the *means* and understanding of the design as
+the *end*. Where a property can be measured against ground truth (small variants,
+endgames), it is; where it cannot, self-play supplies statistical evidence. The
+existing 5×5 design is characterised first; design variants are a stretch that
+tests the robustness of the findings, never the spine.
+
 ## Research question
 
 > **What is the strategic structure of FLIPHEX — does the first player have a
-> provable advantage, does the joker break game balance, and does the game
-> admit an efficient learned policy that approaches optimal play?**
+> provable advantage, does the joker break game balance, is the deck's archetype
+> distribution well designed, and does the game admit an efficient learned policy
+> that approaches optimal play?**
 
 ## Method
 
@@ -30,34 +43,47 @@ argument — stated explicitly, never by narrative.
 
 | ID | Statement | Test | Axis |
 |---|---|---|---|
-| **H1** | With perfect play the first player wins (strictly, since draws are impossible). | Exhaustive solve of the 3×3 variant; 20-seed self-play win rate with Wilson 95% CI on the full game. | 1 + 2 |
-| **H2** | Removing the joker does not change which player holds the theoretical advantage. | Solver + self-play on a joker-less variant. | 1 + 2 |
-| **H3** | The learned policy converges to a stable win-rate across independent seeds, and agrees with the solver's exact verdict on shared variants. | 5-seed training; comparison against Axis 1. | 2 |
+| **H1** | With perfect play the first player wins (strictly, since draws are impossible). | Exhaustive solve of the 3×3 (calibration) and 4×4 (primary strategic) variants; 20-seed self-play win rate with Wilson 95% CI on the full game. | 1 + 2 |
+| **H2** | Removing the joker does not change which player holds the theoretical advantage. | Solver + self-play on a joker-less variant (exact on 3×3/4×4). | 1 + 2 |
+| **H3** | The learned policy converges to a stable win-rate across independent seeds, and agrees with the solver's exact verdict on shared variants. | ≥5-seed training; per-seed win rate with Wilson 95% CI and variance reported across seeds; comparison against Axis 1. | 2 |
 | **H4** | FLIPHEX's state-space complexity is comparable to Reversi 6×6 and strictly below Othello 8×8 and Hex 11×11. | Direct computation of state-space and game-tree bounds. | 3 |
 | **H5** | No archetype dominates placement frequency in self-play, i.e. the 12-tile deck is well balanced. | Frequency and win-contribution analysis over the self-play database. | 2 + 3 |
+| **H6** *(optional / stretch)* | The design's balance is *robust to counterfactual variation* — the first-player advantage and joker effect hold their sign under a bounded set of design perturbations (board size 3×3→4×4→5×5; deck swaps, e.g. removing the chiral `P3-y`). | Re-run the H1/H2 verdicts against each perturbation and report whether the *direction* of the effect is preserved; exact where solvable, self-play otherwise. | 1 + 2 |
 
-Rejecting H1 or H2 would be a genuinely interesting finding: a student-designed
-game that resists trivial first-player domination.
+Under the game-design thesis, **H1, H2, H5** are the spine (they ask directly
+whether the design is balanced and fair); **H3** is the cross-axis honesty check;
+**H4** situates the game. Rejecting H1 or H2 would be a genuinely interesting
+finding: a student-designed game that resists trivial first-player domination.
+
+**H6 is optional and guard-railed.** It turns the "what if we changed the pieces
+or the board?" question into a *robustness* claim about the shipped design, never
+a redesign. It is tested only *after* H1–H5 are settled on the shipped 5×5, uses
+the shipped game as the fixed baseline, and every variant result carries its deck
+and board size explicitly ([adr-009](adr/adr-009-reduced-deck-policy.md)). It may
+be dropped at lock without affecting the spine.
 
 ## Amendments arising from Phase 0
 
 Phase 0 changed the standing of three hypotheses. Recorded here so the eventual
 lock is made with these in view.
 
-**H1 — no symmetry argument is available.** The board's symmetry group is
-trivial ([board-geometry.md](board-geometry.md)): columns A/C/E and B/D sit at
-different vertical centres, so no rotation or reflection maps the cell set onto
-itself. There is therefore no strategy-stealing or pairing argument to lean on,
-and H1 must be settled computationally. This makes H1 *more* interesting and
-strictly harder.
+**H1 — the board's mirror gives no strategy-stealing argument.** The board's
+automorphism group is *not* trivial — it is Z/2, a left-right mirror across
+column C ([adr-008](adr/adr-008-board-mirror-symmetry.md),
+[board-geometry.md](board-geometry.md)) — correcting the Phase 0 claim. But the
+mirror preserves the player to move (it is not a colour swap), so it still yields
+no strategy-stealing or pairing argument. H1 must be settled computationally.
+The Phase 0 *conclusion* was right; its "no symmetry" *premise* was wrong.
 
-**H1 — possible confound from `OPEN-2`.** If the two decks' chiral `P3-y` tiles
-are mirror images of one another (see
-[piece-archetypes.md](piece-archetypes.md)), the two seats do not hold
-equivalent decks, and any first-player advantage measured would mix the
-first-move effect with a deck effect. **This must be resolved before H1 is
-locked.** If it resolves badly, H1 splits into H1a (first-move effect, decks
-equalised) and H1b (deck effect).
+**`OPEN-2` — RESOLVED (2026-07-29): the decks are equivalent.** The two decks'
+`P3-y` tiles are *identical* (same manufacturing mould, same chirality), not
+mirror images, so both players hold `(0,1,3)` on their own face. There is
+therefore **no deck confound for H1** — it is a clean first-move (plus joker)
+question and does not split into H1a/H1b. This clears the last blocker to locking
+the hypotheses. (Per [adr-008](adr/adr-008-board-mirror-symmetry.md), this does
+*not* grant a mirror augmentation: that is blocked separately by the chiral tile
+and is at best a partial, endgame-restricted gain — which is why there is no
+symmetry hypothesis in the table above.)
 
 **H4 — the baseline bound in the roadmap is wrong.** The roadmap's suggested
 state-space expression includes a factor of `6^25` for tile orientations. Placed
@@ -74,6 +100,25 @@ the corrected figure. Note 4.9 × 10¹⁷ sits *below* Reversi 6×6's commonly c
 "comparable to Reversi 6×6" but FLIPHEX now looks smaller. Reword before
 locking; the honest version is a prediction of where FLIPHEX lands, not that it
 lands next to a particular game.
+
+## Amendments arising from Phase 2
+
+**H1/H2 — 4×4 is the primary exact-solve target, not 3×3.** The Phase 2
+complexity sweep (same bound formula, varying board size) puts the
+full-enumeration frontier at **N ≈ 13–15 cells**:
+
+| Board | cells | reachable bound (full deck) |
+|---|--:|--:|
+| 3×3 | 9 | 3.1 × 10⁹ |
+| 4×4 | 16 | 8.3 × 10¹³ (9.3 × 10¹⁰ reduced deck) |
+| 5×5 | 25 | 4.9 × 10¹⁷ |
+
+So 3×3 is a *correctness fixture* (too cramped for tactics like deferring a flip
+to set up a later swing) and **4×4 is the strategically meaningful exact solve**
+carrying the H1/H2 verdicts. Recorded in the
+[adr-004 Phase 2 amendment](adr/adr-004-solver-approach.md). The reduced-deck
+choice that makes 4×4 tractable is pinned in
+[adr-009](adr/adr-009-reduced-deck-policy.md) (Proposed).
 
 ## Verdicts
 

--- a/docs/research.md
+++ b/docs/research.md
@@ -2,7 +2,7 @@
 
 **Status:** DRAFT. Hypotheses are **not yet locked** — locking happens at the
 end of Phase 2 and is marked by the `v0.3-hypotheses` tag, which is what
-timestamps the pre-registration. Until then H1–H5 may be reworded, split, or
+timestamps the pre-registration. Until then H1–H6 may be reworded, split, or
 dropped. After that tag, this file may only gain verdicts; anything else needs
 an ADR.
 
@@ -45,8 +45,8 @@ argument — stated explicitly, never by narrative.
 |---|---|---|---|
 | **H1** | With perfect play the first player wins (strictly, since draws are impossible). | Exhaustive solve of the 3×3 (calibration) and 4×4 (primary strategic) variants; 20-seed self-play win rate with Wilson 95% CI on the full game. | 1 + 2 |
 | **H2** | Removing the joker does not change which player holds the theoretical advantage. | Solver + self-play on a joker-less variant (exact on 3×3/4×4). | 1 + 2 |
-| **H3** | The learned policy converges to a stable win-rate across independent seeds, and agrees with the solver's exact verdict on shared variants. | ≥5-seed training; per-seed win rate with Wilson 95% CI and variance reported across seeds; comparison against Axis 1. | 2 |
-| **H4** | FLIPHEX's state-space complexity is comparable to Reversi 6×6 and strictly below Othello 8×8 and Hex 11×11. | Direct computation of state-space and game-tree bounds. | 3 |
+| **H3** | The learned policy converges to a stable win-rate across independent seeds, and agrees with the solver's exact verdict on **every member of the pre-declared comparison set**: 3×3 (full deck), 4×4 ([adr-009](adr/adr-009-reduced-deck-policy.md) deck), and the 5×5 retrograde endgame layers at the largest `k` achieved. | ≥5-seed training; per-seed win rate with Wilson 95% CI and variance reported across seeds; per-variant agreement rate against Axis 1, restricted to Axis-1 artefacts satisfying [adr-004](adr/adr-004-solver-approach.md) R1 (`termination: exhausted`). | 2 |
+| **H4** | FLIPHEX 5×5 is out of reach on **both** complexity axes: its state space (~4.9 × 10¹⁷) exceeds every game solved by full enumeration (Nine Men's Morris 10¹¹, Awari 10¹², Connect Four 10¹⁴), and its game-tree complexity (~10⁶¹; ~10³⁰·⁵ at the Knuth–Moore minimal tree) puts it beyond the weak-solution route that carried checkers *despite* checkers' larger 5 × 10²⁰ state space. | Direct computation of both bounds; placement in the Allis/Schaeffer cross-game table. | 3 |
 | **H5** | No archetype dominates placement frequency in self-play, i.e. the 12-tile deck is well balanced. | Frequency and win-contribution analysis over the self-play database. | 2 + 3 |
 | **H6** *(optional / stretch)* | The design's balance is *robust to counterfactual variation* — the first-player advantage and joker effect hold their sign under a bounded set of design perturbations (board size 3×3→4×4→5×5; deck swaps, e.g. removing the chiral `P3-y`). | Re-run the H1/H2 verdicts against each perturbation and report whether the *direction* of the effect is preserved; exact where solvable, self-play otherwise. | 1 + 2 |
 
@@ -122,15 +122,57 @@ choice that makes 4×4 tractable is pinned in
 fill by ascending arrow count; reduced boards are a purely computational
 device).
 
+**H3 — the comparison set is now named, because it was going to be n = 1.** As
+originally worded, H3's cross-axis clause said "shared variants" and left the
+count to be discovered in Phase 5. The only variant both axes were committed to
+was the 4×4, so the hypothesis would have rested on a **single** board. Two fixes,
+both already available: [adr-009](adr/adr-009-reduced-deck-policy.md)'s policy
+generates a family of reduced boards, and — more valuable — the **5×5 retrograde
+endgame layers give solver-vs-learner comparison on the shipped game**, not on a
+toy. H3 now enumerates its comparison set explicitly, and restricts it to Axis-1
+artefacts that terminated by exhaustion
+([adr-004](adr/adr-004-solver-approach.md) R1), so no comparison can be drawn
+from a run whose search order was seeded by the learner it is being compared to.
+
+**H4 — reworded onto both complexity axes.** The Phase 0 wording ("comparable to
+Reversi 6×6") was flagged above as probably false against the corrected bound,
+and it was also the wrong *shape* of claim: it asserted proximity to one game
+rather than a position in the landscape. Reading Allis against Schaeffer supplied
+the missing distinction — state-space and game-tree complexity are **independent**
+axes, and checkers was weakly solved with ~1000× *more* states than FLIPHEX 5×5
+because it is easy on the axis that governs a forward proof. H4 now states a
+falsifiable position on both axes and names the datapoints it is measured against.
+
+**Verification is now an ADR, and the verdict table carries an evidence class.**
+The 4×4 solve produces one verdict out of ~10¹¹ states, where the failure mode is
+a *plausible wrong answer* rather than a crash.
+[adr-010](adr/adr-010-solver-correctness.md) fixes the six checks that must pass
+before any Axis-1 number may appear in the table below, and drafts — before the
+result exists — the strongest sentence a single implementation run once is
+entitled to. Its last clause ("it has not been independently reimplemented") is
+what the evidence-class column exists to carry.
+
 ## Verdicts
 
 Empty until Phase 5 and Phase 6. One row per hypothesis, each citing the
 experiment ID in [`experiments/registry.md`](../experiments/registry.md).
 
-| ID | Verdict | Evidence | Experiment | Phase |
-|---|---|---|---|---|
-| H1 | — | | | |
-| H2 | — | | | |
-| H3 | — | | | |
-| H4 | — | | | |
-| H5 | — | | | |
+Every row carries an **evidence class**, because the hypotheses do not all get the
+same *kind* of answer and a bare "supported" erases the difference between an
+enumerated fact and a 20-seed win rate:
+
+- **`exact`** — an exhaustive computation, qualified by its verification status
+  per [adr-010](adr/adr-010-solver-correctness.md). E.g. *"supported (exact,
+  single implementation, V0–V5 passed, not independently reimplemented)"*.
+- **`statistical`** — an estimate with a stated interval and seed count.
+- **`structural`** — a closed-form bound or an argument from the rules, with no
+  run behind it.
+
+| ID | Verdict | Evidence class | Evidence | Experiment | Phase |
+|---|---|---|---|---|---|
+| H1 | — | | | | |
+| H2 | — | | | | |
+| H3 | — | | | | |
+| H4 | — | | | | |
+| H5 | — | | | | |
+| H6 | — | | | | |

--- a/exercises/ex01_rules_formalization.md
+++ b/exercises/ex01_rules_formalization.md
@@ -1,0 +1,195 @@
+# ex01 — Rules formalization
+
+**Phase 1 problem set**, written retroactively (Phase 2). Four problems, from the
+roadmap's *Exercises — After Phase 1*, restated against the engine as it was
+actually built.
+
+**How to use this file.** Write **Answer** in first person, showing the work
+including the wrong turns. **Refined** is written afterwards: corrections,
+completed algebra, and the link back to the code or ADR each result feeds.
+
+**Feeds:** [rules-canonical.md](../docs/rules-canonical.md) §5 (invariants) ·
+[adr-003](../docs/adr/adr-003-piece-representation.md) ·
+[adr-005](../docs/adr/adr-005-alphazero-scope-and-network.md) (action space) ·
+[adr-007](../docs/adr/adr-007-flip-toggles-colour.md)
+
+**Code under discussion:** `fliphex/moves.py` (`legal_moves`, `apply_move`) ·
+`fliphex/piece.py` (`distinct_rotations`) · `fliphex/rules.py` (`outcome`)
+
+> **Note on Q2.** The roadmap states it as "cell × piece × rotation", which
+> invites the answer $25 \times 13 \times 6 = 1950$. **That number is wrong**, and
+> the reason it is wrong is the whole exercise. See Q2(a).
+
+---
+
+## Q1 — The game terminates in exactly 25 plies
+
+**Problem.**
+
+(a) Prove it. The claim is stronger than "terminates": the length is a
+**constant**, not a bound and not a distribution. Structure the proof around a
+monotone quantity and show it advances by exactly one per ply.
+
+(b) The proof has two obligations most sketches skip. Discharge both:
+
+- **The mover always has a legal move.** Show that no reachable state has the
+  mover holding tiles but facing a full board, nor facing empty cells with an
+  empty hand. Use [rules-canonical.md](../docs/rules-canonical.md) §5 **I3** —
+  and note the two hands have *different* sizes (13 and 12), so the two cases are
+  not symmetric.
+- **The game cannot end early.** Is there any rule permitting a pass, a
+  resignation, or a capture that removes a placed tile? Check §3 and §4 rather
+  than assuming.
+
+(c) **The non-obvious dependency.** The monotone quantity in (a) is only monotone
+because of [adr-007](../docs/adr/adr-007-flip-toggles-colour.md). State exactly
+which alternative flip semantics would break the proof, and say what the game's
+length would become under it. (Hint: "flip" could plausibly have meant *remove*
+or *capture to hand*; the ADR chose *toggle colour*.)
+
+(d) Where does the fixed depth get used later? Name at least two downstream
+places — one in the complexity analysis and one in the AZ design — where "$d$ is
+a constant, not a distribution" changes a conclusion.
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Q2 — Counting legal moves
+
+**Problem.**
+
+**(a) Ply 1.** The naive count is $25 \text{ cells} \times 13 \text{ tiles}
+\times 6 \text{ rotations} = 1950$. The true count is **1450**. Explain the gap
+*from first principles* before looking at the code:
+
+- A hex tile may be **rotated** freely but never turned face-down. So the set of
+  arrow patterns a tile can present is its **rotation orbit** — the orbit of its
+  arrow mask under the cyclic group $C_6$ acting on the six direction slots.
+- Some orbits are shorter than 6, because some masks are fixed by a non-trivial
+  rotation. Identify **which** archetypes those are and **why**, using the
+  symmetry of the arrow pattern itself. Work out each orbit size by hand for at
+  least `P6`, `P3-tri` and `P2-opp` before checking against
+  `Piece.distinct_rotations()`.
+- Two distinct (tile, rotation) pairs producing the same pattern would generate
+  duplicate moves with identical successors. Explain why move generation must
+  deduplicate, and what would go wrong in search if it did not (think about the
+  branching factor, the policy target in
+  [adr-005](../docs/adr/adr-005-alphazero-scope-and-network.md), and node counts
+  in any reported benchmark).
+
+Then: sum the orbit sizes over the 13 tiles Player 1 holds, multiply by 25, and
+confirm 1450. Do the same for Player 2, who holds 12 tiles and **no joker** —
+the numbers differ, and the difference is not 1×25.
+
+**(b) The joker.** Its orbit size is 1. Explain why from
+[rules-canonical.md](../docs/rules-canonical.md) §6 without computing anything.
+
+**(c) Ply 12, best and worst case.** At ply 12 it is Player 2 to move. Work out,
+in order: how many cells are filled, how many are empty, and how many tiles the
+mover still holds. Then bound the move count:
+
+$$
+|\text{ACTIONS}(s)| \;=\; (\text{empty cells}) \times \sum_{\text{tiles held}} |\text{orbit}(\text{tile})|
+$$
+
+**Worst case** = the mover holds the tiles with the *smallest* orbits; **best
+case** = the largest. Compute both. State clearly which parts of your answer are
+forced by the rules and which depend on *which* tiles happen to remain — the
+second part is a fact about the deck, and it is why the branching factor decays
+unevenly rather than smoothly.
+
+**(d) Sanity check against the engine.** Verify (a) and (c) with `legal_moves`.
+If your hand-derived worst case disagrees with a hand you can actually construct,
+say which is wrong and why.
+
+**(e) The action space is not the move count.**
+[adr-005](../docs/adr/adr-005-alphazero-scope-and-network.md) sizes the policy
+head over $25 \times 13 \times 6 = 1950$ slots even though at most 1450 are ever
+legal. Is that a bug, a deliberate slack, or a consequence of the factored head?
+Answer from the ADR, and say what the masking step has to do.
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Q3 — Draws are impossible
+
+**Problem.**
+
+(a) Prove it. The usual one-liner is "25 is odd, so the counts cannot be equal" —
+which is **not a complete proof**. It needs two more facts. Name them and prove
+each:
+
+- every cell is occupied at the end (this is Q1, so state the dependency
+  explicitly rather than assuming it), and
+- every occupied cell carries exactly one of **two** colours, with no third state
+  and no neutral cell ([adr-007](../docs/adr/adr-007-flip-toggles-colour.md)).
+
+Only then does parity close the argument.
+
+(b) Write the conclusion as a statement about the codomain of the value function,
+and locate it in `fliphex/rules.py` — which function, and what does it return?
+
+(c) **The invariant as a test.** A draw appearing anywhere is a *proof of a bug*,
+not a position to inspect. That is `V2` in
+[adr-010](../docs/adr/adr-010-solver-correctness.md). Where should the assertion
+live so that it is **total** rather than sampled — in `outcome`, at every database
+write, or both? Justify.
+
+(d) **The trade.** No draws is not purely a gift. Name one thing it makes easier
+for a *backward* (retrograde) computation and one thing it makes harder for a
+*forward* proof. ([S4](../notes/phase2-synthesis.md) has the full answer; try
+first — the forward half is the counter-intuitive one.)
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Q4 — The invariants
+
+**Problem.**
+
+(a) The roadmap asks for *the* invariant preserved by every move: pieces on the
+board = ply number. State it precisely, then prove it is preserved by
+`apply_move` — including the flip step, which touches cells it did not place on.
+
+(b) [rules-canonical.md](../docs/rules-canonical.md) §5 lists **I1–I6**.
+Reproduce them, then classify each as either an **inductive invariant** (must be
+re-established by every move, and the proof of preservation is real work) or a
+**consequence** (follows from the others plus the rules, and needs no separate
+argument). This distinction is what decides which ones deserve an `assert`.
+
+(c) **I3 is the load-bearing one.** It fixes both hand sizes as a function of the
+ply. Show how it makes Q1(b) immediate, and show how it makes the hand a
+*derived* quantity in principle — then explain why the state still stores hands
+explicitly rather than recomputing them from the ply
+([adr-003](../docs/adr/adr-003-piece-representation.md)). The answer is not
+"performance".
+
+(d) **What is deliberately *not* invariant.** `GameState` records `history`, and
+`fliphex/state.py` documents it as "metadata only — never read by search". Argue
+that dropping `history` preserves every invariant in §5, and connect this to
+adr-003's claim that the state is a **sufficient statistic**. Then the sharp
+version: name one rule that, if FLIPHEX had it, would make `history` load-bearing
+and invalidate the transposition table.
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Lessons Learned
+
+_(first-person, at phase close — not ghost-written)_
+
+## Failed Attempts
+
+_(first-person, at phase close — not ghost-written)_

--- a/exercises/ex02_game_theory.md
+++ b/exercises/ex02_game_theory.md
@@ -1,0 +1,289 @@
+# ex02 — Game theory foundations
+
+**Phase 2 problem set.** Six problems, from the roadmap's *Exercises — After
+Phase 2*, restated against what the Phase 2 reading actually established.
+
+**How to use this file.** Write **Answer** in first person, showing the work
+including the wrong turns. **Refined** is written afterwards: corrections,
+completed algebra, and the link back to the ADR each result feeds. Same loop as
+the lit-notes.
+
+**Feeds:** [research.md](../docs/research.md) H4 (Q6) ·
+[adr-004](../docs/adr/adr-004-solver-approach.md) (Q2, Q3, Q4) ·
+[adr-005](../docs/adr/adr-005-alphazero-scope-and-network.md) (Q5) ·
+[adr-010](../docs/adr/adr-010-solver-correctness.md) (Q6c)
+
+**Reading:** [R&N Ch.6](../notes/russell-norvig-aima-ch6-adversarial-search.md) ·
+[Allis 1994](../notes/allis-1994-searching-for-solutions.md) ·
+[Schaeffer 2007](../notes/schaeffer-2007-checkers-is-solved.md) ·
+[Silver 2017](../notes/silver-2017-alphago-zero.md) /
+[2018](../notes/silver-2018-alphazero.md) ·
+[phase2-synthesis.md](../notes/phase2-synthesis.md)
+
+> **Three corrections to the roadmap's original statements**, all established
+> during Phase 2. They are kept visible rather than silently patched, because
+> the corrections are themselves part of the answer.
+>
+> 1. Adversarial search is **Chapter 6** in AIMA 4th ed, not Chapter 5.
+> 2. Q3's `O(b^{d/2})` is the *asymptotic* form. The exact Knuth–Moore count is
+>    $b^{\lceil d/2 \rceil} + b^{\lfloor d/2 \rfloor} - 1$, and for FLIPHEX the
+>    difference between the two is the whole point.
+> 3. **Q6's formula as written in the roadmap is wrong** — three separate errors.
+>    Diagnosing them *is* the exercise; see Q6.
+
+---
+
+## Q1 — The minimax theorem, and which theorem it actually is
+
+**Problem.**
+
+(a) State precisely what is guaranteed for a finite, two-player, zero-sum game of
+perfect information, and **name the right theorem**. Careful: "the minimax
+theorem" usually means von Neumann's result about *mixed* strategies in
+simultaneous zero-sum games, which needs randomisation. The result that applies
+to FLIPHEX is the backward-induction one (Zermelo / Kuhn) and it gives something
+stronger — say what, and say why the extra strength comes from *sequential*
+perfect information rather than from being zero-sum.
+
+(b) Sketch the proof by induction on tree depth. Base case: terminal nodes. Step:
+assume every child of $s$ has a well-defined value; construct the value of $s$.
+State the induction hypothesis explicitly — most sketches skip it and the proof
+does not survive.
+
+(c) FLIPHEX is a clean instance. Justify each condition against the code, not
+against intuition: **finite** (what bounds the depth, exactly?), **perfect
+information** ([rules-canonical.md](../docs/rules-canonical.md) §2.4),
+**deterministic**, **zero-sum**. Then: where does zero-sum enter the engine
+concretely — which function, and what would break if a rule change made the game
+non-zero-sum?
+
+(d) Draws are impossible (25 cells, odd). What does that do to the *codomain* of
+the value function, and name one thing it makes easier and one thing it makes
+harder. (The second half is the trap; [S4](../notes/phase2-synthesis.md) has the
+answer if you get stuck, but try first.)
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Q2 — Deriving alpha-beta, and what it returns when it prunes
+
+**Problem.**
+
+(a) Derive alpha-beta from minimax. Define $\alpha$ and $\beta$ as *invariants*
+maintained on the path from the root — "the best value MAX can already guarantee"
+and its dual — not as parameters that happen to get passed down.
+
+(b) Prove the root value is unchanged. The argument is: whenever a branch is cut,
+show the cut branch could not have influenced the root. Do this for a MAX node
+and let the MIN case follow by symmetry.
+
+(c) **The part that matters for this project.** After a cutoff, `MAX-VALUE`
+does not return the minimax value of the node — it returns a **bound**. Write the
+three cases:
+
+$$
+\text{ALPHA-BETA}(s,\alpha,\beta)
+\begin{cases}
+\le \alpha & \text{fail-low} \\
+= v(s) & \alpha < v < \beta \\
+\ge \beta & \text{fail-high}
+\end{cases}
+$$
+
+Now the consequence: a transposition table storing these results must store a
+*flag* alongside each value. Which flags, and what goes wrong if you store the
+number alone? Then the bigger consequence — does an alpha-beta search over the
+whole game tree yield a **strong** solution in Allis's sense, a **weak** one, or
+neither? Justify from (c), not from the size of the tree.
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Q3 — Perfect ordering: the exact count, not the asymptotic one
+
+**Problem.**
+
+(a) Derive the best-case node count under perfect move ordering. Sketch the
+structure: at a node on the principal variation all $b$ children must be
+examined; at a node one ply below, a single child suffices to produce the cutoff.
+Alternating those two levels gives the **Knuth–Moore** result
+
+$$
+N_{\min}(b,d) = b^{\lceil d/2 \rceil} + b^{\lfloor d/2 \rfloor} - 1 .
+$$
+
+Derive it; do not quote it. Then show it is $\Theta(b^{d/2})$ so the roadmap's
+form is the asymptotic shadow of this.
+
+(b) Apply it to FLIPHEX. Note $d$ is a **constant**, not a distribution: 25
+cells, exactly one placement per ply, no passes and no captures, so every game is
+exactly 25 plies. With $b_0 = 1450$ falling as cells fill and hands empty, the
+game-tree complexity is ~$10^{61}$. Compute $N_{\min}$ for the 5×5 and for the
+4×4 (adr-009 deck), using a sensible average $b$ for each — state the averaging
+assumption you make and why it is defensible.
+
+(c) **The punchline.** Compare each $N_{\min}$ to the corresponding *state count*
+(4×4: $9.3 \times 10^{10}$; 5×5: $4.9 \times 10^{17}$). One of the two variants
+is search-bound and the other is not. Which, by how many orders of magnitude, and
+what does that imply about where engineering effort should go for the 4×4 exact
+solve? Check your conclusion against
+[adr-004's 2026-08-05 amendment](../docs/adr/adr-004-solver-approach.md) item 2 —
+it should be the same finding, derived independently.
+
+(d) Where does *iterative deepening* fit, given it re-searches shallower depths
+repeatedly? Quantify the waste for $b$ in the hundreds, and say what it buys that
+makes the waste worth paying (R&N §6.2.4 is explicit).
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Q4 — Transposition tables and Zobrist hashing
+
+**Problem.**
+
+(a) Explain why Zobrist hashing is $O(1)$-updatable per move. The property doing
+the work is that XOR is its own inverse and is commutative/associative — show how
+that turns "recompute the hash" into "toggle the changed components".
+
+(b) Count the random words FLIPHEX needs, given the key is
+`(cell, colour)` and `(player, tile)` per
+[adr-003](../docs/adr/adr-003-piece-representation.md). *(The original adr-004
+said 50; the 2026-08-05 amendment corrects it. Derive the number yourself before
+looking.)* Then write the exact XOR sequence for one ply: purple places a tile on
+cell $c$ whose arrows flip two enemy cells. How many XORs total, and what does
+each one toggle?
+
+(c) **Sufficiency, which is the real correctness question.** A TT is sound only
+if the key is a *sufficient statistic*: two states with the same key must have
+identical futures. Argue this for FLIPHEX from adr-003's inertness result — what
+is deliberately **not** in the key, and why is leaving it out safe here when it
+would not be in a game where placed pieces retain state? What would break if
+[adr-006](../docs/adr/adr-006-no-chain-reaction.md) (flips never chain) were
+false?
+
+(d) Two pitfalls. **Collisions:** with a 64-bit key and $n$ stored entries,
+estimate the collision probability by the birthday bound for $n$ at the 4×4
+scale, and say whether it matters given
+[adr-010](../docs/adr/adr-010-solver-correctness.md). **Replacement policy:**
+name two policies and say which suits a *depth-limited search* versus a
+*retrograde enumeration* — and whether the second even needs a TT.
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Q5 — PUCT against UCB1: derive one, and explain why the other cannot be
+
+**Problem.** The formula:
+
+$$
+a^* = \arg\max_a\left[Q(s,a) + c_{\text{puct}} \cdot P(s,a) \cdot \frac{\sqrt{\sum_b N(s,b)}}{1 + N(s,a)}\right]
+$$
+
+(a) Identify each term's role (exploitation, prior, exploration) and write the
+UCB1 selection rule beside it.
+
+(b) **Derive UCB1** from Hoeffding's inequality: for a mean of $n$ bounded i.i.d.
+samples, get the confidence radius, choose the confidence level that yields the
+$\sqrt{\ln N / n}$ form, and state what "optimism in the face of uncertainty"
+means once you have it.
+
+(c) Now show that **PUCT is not derivable the same way** — it is not a
+concentration bound on anything. Compare the two exploration terms on three
+points: their value at $n(a) = 0$; their decay in $n(a)$ at fixed total $N$
+($1/n$ versus $1/\sqrt{n}$); and what each one's guarantee is *conditional on*.
+State plainly what is traded.
+
+(d) **The FLIPHEX question.** $b_0 = 1450$. Show that plain UCT must spend its
+first 1450 simulations before its formula distinguishes any child, and conclude
+whether the UCT → PUCT substitution is *required* here or merely convenient.
+Then the other half: AlphaZero also removes the rollout — is *that* required for
+FLIPHEX? (Consider: playout length, termination, and whether R&N §6.4's
+early-playout-termination machinery has anything to do here.) The two answers
+differ; that difference is the point of the question and it is what
+[adr-005's amendment](../docs/adr/adr-005-alphazero-scope-and-network.md) item 3
+turns on.
+
+(e) The substitution nobody lists: search visit counts become the policy training
+target, $\pi \propto N^{1/\tau}$. Why is *that* the change that makes AlphaZero
+more than guided MCTS?
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Q6 — The state-space bound: find the errors, then derive it properly
+
+**Problem.** The roadmap poses this exercise as:
+
+> Estimate a preliminary upper bound for FLIPHEX's state-space size, using
+> $\binom{25}{12} \times \binom{13}{12}$ (choice of empty cell × player-1 pieces
+> × player-2 pieces) × orientations $(6^{25})$ × joker states (2).
+
+**(a) That expression is wrong in three independent ways. Find them before
+reading on.** One is a **modelling error** that an ADR overturned; one is a
+**double-count**; and the combinatorial core is **mis-stated** — both in what it
+claims to be choosing and in what it silently omits (there is a factor missing
+that has nothing to do with the other two). For each: name it, say what the
+correct treatment is, and cite the document that settles it.
+
+**(b) Derive the corrected bound.** Sum over the number of filled cells $t$:
+
+$$
+\sum_{t=0}^{25} \binom{25}{t} \cdot 2^{t} \cdot \binom{13}{\lceil t/2 \rceil} \cdot \binom{12}{\lfloor t/2 \rfloor} \;\approx\; 4.89 \times 10^{17}
+$$
+
+Justify **every factor**: why $\binom{25}{t}$, why $2^t$ and not $3^t$, why the
+two hand terms have different upper indices (13 and 12 — see
+[rules-canonical.md](../docs/rules-canonical.md) §2, and note both players play
+*all* their tiles), and why the ceiling/floor split is forced. Then state what
+the expression **over-counts** — it is an upper bound on reachable states, not a
+count of them — and name the mechanism by which a counted configuration can fail
+to be reachable.
+
+**(c) The layer profile, which is where the exercise earns its keep.** Evaluate
+the summand as a function of $t$ and plot or tabulate it. Answer:
+
+- Where does it peak, and what fraction of the total sits in that layer?
+- What is the terminal layer $t = 25$, in closed form? (You should get a number
+  small enough to enumerate in seconds — this is exactly why
+  [adr-010](../docs/adr/adr-010-solver-correctness.md) makes `V0` verification
+  zero.)
+- The shape is a **hump**, not a funnel. Contrast with checkers, where captures
+  are irreversible. Why does that shape mean FLIPHEX has no *early* convergence
+  to exploit, and why does it kill meet-in-the-middle enumeration?
+
+**(d) Place FLIPHEX on both Allis axes, for H4.** State-space and game-tree
+complexity are independent. Fill in the row for FLIPHEX 5×5 and 4×4 against
+Nine Men's Morris ($10^{11}$), Awari ($10^{12}$), Connect Four ($10^{14}$) and
+checkers ($5 \times 10^{20}$). Then answer the question H4 now asserts: **checkers
+has ~1000× more states than FLIPHEX 5×5 and was solved — why will FLIPHEX 5×5
+not be?** The answer must use both axes, and it must name the quantity that
+actually binds.
+
+**Answer.**
+
+**Refined.**
+
+---
+
+## Lessons Learned
+
+_(first-person, at phase close — not ghost-written)_
+
+## Failed Attempts
+
+_(first-person, at phase close — not ghost-written)_

--- a/experiments/registry.md
+++ b/experiments/registry.md
@@ -8,7 +8,7 @@ Freely editable (append-only in practice).
 ## Format
 
 - **ID** — `EXP-NNN`, allocated in order, never reused.
-- **Hypothesis** — H1–H5, or `—` for exploratory runs.
+- **Hypothesis** — H1–H6, or `—` for exploratory runs.
 - **Status** — `registered` → `running` → `complete` / `abandoned`.
 - **Seed** — the RNG seed. Required. `—` only for deterministic exhaustive solves.
 - **Result** — one line, with a CI or an exact value. Links to the notebook or figure.
@@ -30,6 +30,8 @@ registration, not here.
 | 3 | Exhaustive solve of the 4×4 variant (stretch) | H1, H2 |
 | 3 | Retrograde endgame database, `k ≤ 5` empty cells on 5×5 | H3 |
 | 3 | Alpha-beta + endgame DB vs random and heuristic, 1000 games | — |
+| 3 | **adr-010 V3** — 3×3 solved twice (forward alpha-beta vs retrograde), values must match on every position | — |
+| 3 | **adr-010 V4** — random-sample re-derivation of 4×4 entries by direct search, database not consulted | — |
 | 4 | AZ training run, seed 1, to 1M self-play positions | H3 |
 | 4 | AZ training run, seed 2 (convergence replication) | H3 |
 | 4 | Factored vs flat policy head (adr-005 risk R5) | — |
@@ -39,3 +41,6 @@ registration, not here.
 | 5 | Sensitivity: MCTS simulations, `c_puct`, temperature schedule | — |
 | 6 | State-space and game-tree bounds; cross-game comparison table | H4 |
 | 6 | Archetype placement frequency and win contribution | H5 |
+| 6 | **Tile criticality** — for each archetype, the fraction of solved 4×4 positions whose value changes when that tile is removed from the hand | H5 |
+| 6 | **Mirror-optimality rate** — on solved positions where the Z/2 mirror is a valid game symmetry (both `P3-y` placed), the fraction of optimal moves whose mirror image is also optimal | H5, H6 |
+| 6 | **First-player advantage curve** — fraction of solved positions at each ply `t` won by the player to move, 4×4 | H1 |

--- a/notes/allis-1994-searching-for-solutions.md
+++ b/notes/allis-1994-searching-for-solutions.md
@@ -1,0 +1,318 @@
+# Reading companion — Allis 1994, Searching for Solutions in Games and AI
+
+**Citation.** Allis, L. V. (1994). *Searching for Solutions in Games and
+Artificial Intelligence.* PhD thesis, University of Limburg (Maastricht), the
+Netherlands. Read from the Maastricht CRIS open-access copy
+(`refs/allis-1994-searching-for-solutions.pdf`).
+
+**Why this source, and where it sits.** This is the **Axis 3 (complexity)**
+foundation and part of the Axis 1 (solver) grounding. It gives (a) the standard
+vocabulary for *what it means to solve a game* (ultra-weak / weak / strong), (b)
+the two complexity measures — **state-space complexity** and **game-tree
+complexity** — and the canonical **comparison table** across games that H4 needs,
+and (c) **proof-number search**, an AND/OR solving technique relevant to adr-004.
+Read after the AlphaZero papers (Axis 2) — this rounds out the *exact-solving*
+side. **Directed reading:** the complexity framework and pn-search, not the
+game-specific case studies in full.
+
+**Cross-refs this reading feeds:**
+- **H4** in [research.md](docs/research.md) — the complexity comparison; Allis is
+  the reference for the metrics *and* the competitor numbers (Reversi, Hex,
+  Connect-Four). Note H4 is already flagged as possibly-false against the
+  corrected FLIPHEX bound (~4.9×10¹⁷); this reading sharpens the comparison.
+- [adr-004](docs/adr/adr-004-solver-approach.md) — the solve-ability taxonomy and
+  proof-number search as a possible complement to alpha-beta.
+- `complexity/` package (Phase 6): `state_space.py`, `game_tree.py`,
+  `comparison.py` implement Allis's measures directly.
+- [exercises/ex05_complexity_analysis.md](exercises/ex05_complexity_analysis.md)
+  — the state-space / game-tree derivations land here.
+- research.md §"Amendments" — the corrected FLIPHEX state-space bound.
+
+**Legend.** Prompts marked 🔄 need synthesis with another source — answer them in
+[phase2-synthesis.md](notes/phase2-synthesis.md) (esp. **S4**: exact solving vs
+learned play), not here.
+
+**Reading material** (extracted via `paper-study`, gitignored under
+`notes/sources/`). Chapter mapping (the thesis chapters, not this note's §):
+[manifest](sources/allis-1994-searching-for-solutions/manifest.json) ·
+[§6 Introduction](sources/allis-1994-searching-for-solutions/sections/06-introduction.md)
+(the "solved" definitions → this note's §1) ·
+[§11 "Which Games Will Survive?"](sources/allis-1994-searching-for-solutions/sections/11-which-games-will-survive.md)
++ [Nível-1 companion](sources/allis-1994-searching-for-solutions/study/11-which-games-will-survive.md)
+(complexity + comparison + taxonomy → this note's §2/§3/§5/§6) ·
+[§7 Proof-Number Search](sources/allis-1994-searching-for-solutions/sections/07-proof-number-search.md)
+(→ this note's §4). Note: the Figure 6.1 complexity plot and the exponents in the
+comparison numbers are images/superscripts and did **not** extract — canonical
+published values are transcribed in the §11 companion.
+
+---
+
+## §1 — What "solving a game" means
+
+### 1.1 — Ultra-weakly, weakly, strongly solved
+**Prompt.** Write Allis's three definitions exactly. Which one requires only the
+game-theoretic *value* of the initial position, which adds a *strategy* from the
+start, and which demands the value of *every* legal position? Predict before
+reading: which term matches "we know who wins 3×3 FLIPHEX with perfect play"?
+
+**My take.**
+
+Allis distinguishes three increasingly stronger notions of solving a deterministic, perfect-information game.
+
+**Ultra-weakly solved**
+
+A game is *ultra-weakly solved* when only the game-theoretic value of the initial position is known. In other words, we know whether perfect play from the starting position leads to a win, loss, or draw, but no explicit strategy is required.
+
+**Weakly solved**
+
+A game is *weakly solved* when the game-theoretic value of the initial position is known and an optimal strategy exists from the starting position. A weak solution therefore tells us both the outcome and how to achieve it from the beginning of the game.
+
+**Strongly solved**
+
+A game is *strongly solved* when the game-theoretic value is known for every legal position, together with an optimal strategy from each of those positions. This guarantees perfect play even if one or both players have previously deviated from the optimal line.
+
+The three notions can be summarized as follows:
+
+| Solution level | What is known? |
+| --- | --- |
+| Ultra-weak | Only the game-theoretic value of the initial position. |
+| Weak | The value of the initial position and an optimal strategy from the start. |
+| Strong | The value and optimal strategy for every legal position. |
+
+The statement *"we know who wins 3×3 FLIPHEX with perfect play"* most naturally corresponds to an **ultra-weak solution**, since it only states the game-theoretic outcome of the initial position. It becomes a **weak solution** if an explicit winning strategy from the initial board is also known, and a **strong solution** only if every legal board position has been analyzed and solved.
+
+**Refined write-up.**
+
+Allis's three levels are nested by *how much is known*. **Ultra-weak** = the game-theoretic value of the *initial* position only (who wins under perfect play), with no strategy. **Weak** = that value *plus* a strategy that achieves it from the start. **Strong** = the value and an optimal move for *every* legal position, so play stays perfect even after a mistake. "We know who wins 3×3 FLIPHEX" is bare **ultra-weak**; add a constructive line from the opening and it is **weak**; solve every 3×3 position and it is **strong**. The FLIPHEX-specific point: unlike Hex — ultra-weakly solved by strategy-stealing — FLIPHEX's Z/2 mirror *preserves the mover* (adr-008), so there is no existence shortcut. Its who-wins question can only be answered by a **constructive** weak or strong solve, never by an argument.
+
+### 1.2 — Which target does the FLIPHEX solver claim?
+**Prompt.** Map each Phase 3 deliverable to a term: the exhaustive 3×3 solve, the
+retrograde endgame database on 5×5, and the alpha-beta agent that "plays
+optimally on solved variants." Which are weak, which are strong, and where does
+the endgame DB sit? (This wording should end up in adr-004 and the Phase 3 note.)
+
+**My take.**
+
+The Phase 3 deliverables target different notions of solving as defined by Allis.
+
+The **exhaustive 3×3 solver** aims for a **strong solution**. By exhaustively enumerating every legal position and determining its game-theoretic value together with the optimal move, it provides perfect play from any reachable state.
+
+The **5×5 retrograde endgame database** is also a **strong solution**, but only over a restricted subspace of the game. Every position contained in the database is solved exactly, allowing optimal play whenever the search reaches one of those positions. It is therefore a *partial strong solution* rather than a solution of the complete game.
+
+The **alpha-beta agent** is not itself a solution to the game. Instead, it is a search algorithm capable of exploiting solved information. When applied to a solved variant such as 3×3, it can reproduce the optimal strategy and therefore play perfectly. On unsolved variants, however, it performs exact search only within its search horizon and should be regarded as an optimal decision procedure rather than as a weak or strong solution.
+
+Consequently, the project claims a **strong solution** for the fully solved 3×3 variant, a **partial strong solution** through retrograde analysis for selected 5×5 endgames, and an **exact search engine** that exploits these solved components rather than solving the general game itself.
+
+**Refined write-up.**
+
+Mapping the Phase 3 deliverables (adr-004, Phase 2 amendment): the exhaustive **3×3** solve is a *strong* solution but functions as a **calibration fixture** — it validates engine and search, not strategy. The **4×4** solve is now the *primary* exact target (~9 × 10¹⁰ reachable states with a reduced deck); it is the *strong* solution that carries the H1/H2 verdicts on a strategically non-trivial board. The **5×5 retrograde endgame database** is a *partial strong* solution — exact only over the `k ≤ 5` empty-cell slice. The **alpha-beta agent** is not itself a solution: it is the exact-search *engine* that consumes solved information (the endgame DB as a perfect evaluator) and, decisively, the **ground-truth oracle** against which the AlphaZero agent is checked (H3). It is not a weaker prototype of the learned agent but its *independent* verifier — the two axes must fail differently.
+
+---
+
+## §2 — State-space complexity
+
+### 2.1 — Definition and how to count it
+**Prompt.** Allis's state-space complexity = the number of *legal* positions
+reachable from the initial position. How does he actually estimate it when exact
+enumeration is infeasible (bounds, sampling)? What is the difference between the
+*naïve* count and the *reachable* count, and why does it matter?
+
+**My take.**
+
+Allis defines **state-space complexity** as the number of **legal positions reachable from the initial position**. The emphasis on *reachable* is essential: many board configurations that satisfy the local rules of a game can never arise through a valid sequence of moves and therefore do not belong to the game's state space.
+
+For small games, the state-space complexity can be obtained by exhaustive enumeration of all reachable positions. For larger games, however, exact enumeration quickly becomes computationally infeasible. In these cases, Allis advocates estimating the state space using mathematical upper and lower bounds, combinatorial analysis, and, when appropriate, statistical sampling techniques.
+
+A naïve count simply considers every possible assignment of pieces to board locations while enforcing only basic occupancy constraints. This approach generally overestimates the true complexity because it ignores move legality, game dynamics, and unreachable configurations.
+
+The reachable count instead includes only positions that can actually be generated from the initial position by a legal sequence of moves. This measure more accurately reflects the effective search space faced by a solver and provides a meaningful basis for comparing the complexity of different games.
+
+Consequently, state-space complexity measures the size of the game's reachable configuration space rather than the total number of syntactically valid board arrangements.
+
+**Refined write-up.**
+
+State-space complexity counts **reachable legal** positions, not syntactically valid ones — and the gap is large, because move dynamics make most locally-valid boards unreachable. Small games: enumerate directly. Large games: bound from above, tighten with game-specific constraints, then estimate the *legal fraction* by Monte-Carlo — Allis's tic-tac-toe example samples the 3⁹ superset and recovers the true 5,478. The reachable count is what a solver actually faces; the naïve count systematically overstates it.
+
+### 2.2 — FLIPHEX's number against the framework
+**Prompt.** Our corrected reachable bound is ~4.9×10¹⁷ (adr-003 inertness drops
+the 6²⁵ orientation factor; see research.md §Amendments). Is that a *state-space
+complexity* in Allis's sense, or just an upper bound? What would Allis do to
+tighten it, and does our number already use those ideas (turn-parity,
+deck-composition constraints)?
+
+**My take.**
+
+The corrected FLIPHEX estimate of approximately **4.9×10¹⁷** should be interpreted as an **upper bound** on the state-space complexity rather than the state-space complexity itself.
+
+According to Allis, the state-space complexity is the exact number of legal positions reachable from the initial position. Since exhaustive enumeration of all reachable FLIPHEX positions has not been performed, the exact value remains unknown. Our estimate therefore bounds the reachable state space instead of measuring it exactly.
+
+The bound is nevertheless considerably tighter than a naïve combinatorial count because it incorporates game-specific constraints. In particular, it removes impossible tile orientations through the inertness result (ADR-003) and accounts for structural constraints such as turn parity and deck composition, thereby excluding large classes of impossible configurations.
+
+Following Allis's methodology, the next step toward a more accurate estimate would be to introduce additional reachability constraints or, ideally, enumerate the reachable positions directly for tractable board sizes. Every valid constraint that eliminates unreachable configurations narrows the gap between the upper bound and the true state-space complexity.
+
+Therefore, the current FLIPHEX estimate should be regarded as a progressively refined upper bound obtained by incorporating domain knowledge, rather than as the exact state-space complexity defined by Allis.
+
+**Refined write-up.**
+
+FLIPHEX's ~4.9 × 10¹⁷ is an **upper bound**, not the state-space complexity in Allis's exact sense. It already folds in domain constraints: inertness drops the `6²⁵` orientation factor (adr-003); turn-parity fixes the P1/P2 ply split; deck composition caps the two hand factors. What it does *not* do is subtract flip-unreachable colourings — the `2^t` term treats *every* 2-colouring of the occupied cells as reachable, which the flip dynamics do not guarantee. Allis's own next step would be exactly that subtraction: a Monte-Carlo estimate of the legal fraction. That is the open refinement earmarked for `complexity/state_space.py` (Phase 6), and it would move the number *down*, never up.
+
+---
+
+## §3 — Game-tree complexity
+
+### 3.1 — Definition and estimation (b^d)
+**Prompt.** Game-tree complexity = the number of leaf nodes of the *solution
+search tree*, usually estimated as `b^d` with `b` = average branching factor and
+`d` = game length. How does Allis obtain `b` and `d` in practice? For FLIPHEX,
+`d = 25` (fixed!) — how does a fixed game length change the estimate versus games
+where `d` varies?
+
+**My take.**
+
+Allis defines **game-tree complexity** as the number of leaf nodes in the solution search tree. Since exact enumeration is infeasible for most games, this quantity is typically approximated as \(b^d\), where \(b\) is the average branching factor and \(d\) is the average game length.
+
+In practice, the average branching factor is obtained by analyzing representative games or by estimating the average number of legal moves available across the search tree. The game length is estimated from complete games, either by theoretical analysis or empirical observation, depending on the game.
+
+Unlike state-space complexity, game-tree complexity measures the size of the search required to solve the game rather than the number of distinct reachable positions.
+
+For FLIPHEX, the game length is fixed at **25 plies** on a 5×5 board because exactly one tile is placed per turn until the board is full. This removes one source of uncertainty from the estimate: the depth of the search tree is known exactly, leaving the average branching factor as the primary variable determining the game-tree complexity.
+
+A fixed game length also makes comparisons across board sizes more straightforward, since changes in complexity arise primarily from variations in the branching factor rather than from fluctuations in game duration.
+
+**Refined write-up.**
+
+Game-tree complexity = leaves of the solution search tree, estimated as `bᵈ`, with `b` and `d` read off tournament games. FLIPHEX is unusual: `d = 25` is *fixed* (one tile per ply until the board fills), so all uncertainty leaves the depth and the estimate reduces to characterising `b` — which starts at **1450** and collapses to **1** at ply 25 (adr-004). Fixed depth also makes cross-board comparison clean: from 3×3 to 5×5, complexity moves with `b` alone, not with fluctuating game length.
+
+### 3.2 — The comparison table (H4's reference data) 🔄
+**Prompt.** Copy the rows Allis gives for the games H4 names or their neighbours:
+Reversi/Othello, Connect-Four, and (if present) any Hex figures. Record both
+state-space and game-tree complexity. **Do not import them as ours** — they are
+reference points. Where does FLIPHEX's ~4.9×10¹⁷ fall relative to Reversi? (H4 as
+worded may already be false — this is the data that decides it.)
+
+**My take.**
+
+Allis reports the following reference values for games closely related to H4:
+
+| Game | State-space complexity | Game-tree complexity |
+| --- | ---: | ---: |
+| Connect-Four | ≈ 4.5 × 10¹² | ≈ 1 × 10²¹ |
+| Reversi (Othello) | ≈ 1 × 10²⁸ | ≈ 1 × 10⁵⁸ |
+
+No canonical Hex figures are provided in the comparison table used in this reading, so no Hex values are recorded here.
+
+These numbers are reference points taken directly from Allis and should not be interpreted as measurements of FLIPHEX.
+
+Using the current corrected estimate, FLIPHEX has a reachable state-space upper bound of approximately **4.9 × 10¹⁷**. This places it roughly **five orders of magnitude larger than Connect-Four** (≈10⁵ times) but still **about ten orders of magnitude smaller than Reversi** in terms of state-space complexity.
+
+Therefore, the current evidence does **not** support claiming that FLIPHEX has a larger state-space complexity than Reversi. Whether H4 remains valid depends on its precise wording and should be revisited during the Phase 2 synthesis.
+
+**Refined write-up.**
+
+Reference points (Allis's, not ours): Connect-Four ≈ 10¹³ state / ≈ 10²¹ tree; Othello 8×8 ≈ 10²⁸ / ≈ 10⁵⁸. FLIPHEX's ~4.9 × 10¹⁷ upper bound sits well *above* Connect-Four and ~10 orders *below* Othello — and below Reversi 6×6's commonly cited ~10²⁰. So **H4 as worded ("comparable to Reversi 6×6") is likely false**: FLIPHEX looks smaller. The honest reformulation is a *placement prediction* — "lands near 10¹⁸, between Connect-Four and Othello" — not equivalence to a named game (research.md §Amendments). Reversi 6×6 and Hex are absent from Allis's table and need a second source before H4 can name them.
+
+---
+
+## §4 — Proof-number search (solver technique — directed)
+
+### 4.1 — The idea, and when it beats alpha-beta
+**Prompt.** Proof-number search is a best-first AND/OR search that expands the
+node most likely to (dis)prove the root. What are *proof number* and *disproof
+number*, and why does pn-search shine on trees with non-uniform branching and
+clear terminal/goal structure? Would FLIPHEX (fixed depth 25, flip-driven
+terminal-by-fullness) suit it, or is alpha-beta + TT (adr-004) the better fit?
+This is an adr-004 input, not a commitment.
+
+**My take.**
+
+Proof-number search (PNS) is a best-first search algorithm for AND/OR trees designed to determine the game-theoretic value of a position. Rather than exploring the tree uniformly, it repeatedly expands the node that appears most promising for proving or disproving the value of the root.
+
+Each node is assigned two measures:
+
+- The **proof number (pn)** estimates the minimum amount of work required to prove that the node is a win for the player to move.
+- The **disproof number (dn)** estimates the minimum amount of work required to refute that claim.
+
+These values are propagated through the AND/OR tree according to the logical structure of the game, allowing the search to focus computational effort on the most critical parts of the tree.
+
+Compared with alpha-beta search, PNS is particularly effective when the search tree is highly irregular, the branching factor varies substantially across positions, and terminal or goal states provide clear evidence for proving or disproving a position. Under these conditions, best-first expansion can avoid exploring large portions of the tree that alpha-beta might still need to visit.
+
+FLIPHEX exhibits several characteristics that make PNS worth considering. The game has a fixed maximum depth of 25 plies and a well-defined terminal condition when the board becomes full. However, whether these properties outweigh the advantages of alpha-beta with transposition tables depends on the actual structure of the search space, the prevalence of transpositions, and the effectiveness of move ordering. At this stage, PNS should be regarded as a plausible alternative to investigate rather than a committed design choice.
+
+**Refined write-up.**
+
+Proof-number search is best-first AND/OR search on two counters — the **proof number** (minimum work to prove a win) and the **disproof number** (minimum to refute it) — always expanding the most-proving node. Its edge appears where the tree is irregular *and there is a goal to prove*: sudden-death games such as qubic and go-moku, where a forced threat sequence is the thing being demonstrated. FLIPHEX is diverging + fixed-termination with **no** sudden-death pattern (Allis's Othello class), so pn-search loses that structural advantage; alpha-beta + TT + shallow retrograde (adr-004) is the better fit. **Decision recorded:** this reading *confirms* adr-004 rather than reopening it — pn-search stays a parked alternative, revived only if the paper track activates. (adr-004 Phase 2 amendment.)
+
+---
+
+## §5 — Case study: weakly solving a real game
+
+### 5.1 — Connect-Four, and the FLIPHEX analogue
+**Prompt.** Allis weakly solved Connect-Four. What made it tractable (knowledge
+rules, search, or both), and what was the game-theoretic result? What is the
+transferable lesson for *weakly solving* small FLIPHEX variants — is brute-force
+search enough, or did Allis need game-specific knowledge that FLIPHEX lacks?
+
+**My take.**
+
+Allis weakly solved Connect-Four by combining powerful search techniques with substantial game-specific knowledge. The solution was not obtained through brute-force search alone. Instead, knowledge rules were used to recognize strategically significant positions, reduce the effective search space, and guide the solver toward promising lines of play.
+
+The search algorithm and the domain knowledge complemented each other. Search provided completeness, while the knowledge rules greatly improved efficiency by avoiding unnecessary exploration. This combination made the problem computationally tractable despite the enormous theoretical game-tree complexity.
+
+The game-theoretic result was that **the first player has a forced win under perfect play**.
+
+For FLIPHEX, the main lesson is that weakly solving even relatively small variants may require more than exhaustive search. If the search space remains small enough, brute-force enumeration may be sufficient. However, as board size increases, incorporating game-specific knowledge, pruning techniques, or other domain-dependent optimizations may become essential to achieve tractability.
+
+Therefore, Allis's work suggests that successful game solving depends not only on search algorithms but also on exploiting the structural properties of the game itself.
+
+**Refined write-up.**
+
+Allis weakly solved Connect-Four — a **first-player win** — and crucially *not* by brute force alone: knowledge rules (the program VICTOR) carried much of it, and later pn-search cut the cost to under 25 CPU-hours. The lesson for FLIPHEX: brute force suffices only while the state space stays small (3×3, 4×4). FLIPHEX has *no* human-derived knowledge rules of Connect-Four's kind, so pushing the exact solve past 4×4 would demand domain knowledge we don't possess — which is precisely why the plan places strong 5×5 play on the **learned** axis (AlphaZero), not the solver. The solver owns the small boards where enumeration is honest; the learner owns the full game.
+
+---
+
+## §6 — Limitations and caveats of the numbers
+
+### 6.1 — How much to trust a 1994 estimate
+**Prompt.** Allis's complexities are *estimates* (bounds and heuristics), and the
+thesis is from 1994 — several listed games have since been solved or re-measured.
+Which numbers are firm and which are order-of-magnitude guesses? What does this
+imply for how H4 should state its verdict (a precise ranking vs a
+"FLIPHEX lands near here" band)?
+
+**My take.**
+
+The complexity values reported by Allis should primarily be interpreted as **order-of-magnitude estimates** rather than exact measurements. For many games, exact state-space or game-tree complexities were computationally infeasible to determine in 1994, so the reported values were derived from combinatorial arguments, upper and lower bounds, and heuristic estimates.
+
+The definitions of **state-space complexity**, **game-tree complexity**, and the taxonomy of solved games remain fundamental contributions of the thesis. In contrast, some numerical values in the comparison table should be viewed as historical reference points, since subsequent research has refined the estimates or even solved games that were still open at the time.
+
+Consequently, the comparison table is most reliable for identifying relative scales of complexity rather than establishing precise numerical rankings between games.
+
+For H4, this implies that the conclusion should avoid claiming an exact ordering unless supported by rigorous analysis. Instead, the hypothesis should position FLIPHEX within the appropriate order of magnitude and discuss its complexity relative to established reference games while acknowledging the uncertainty inherent in both the historical estimates and the current FLIPHEX upper bound.
+
+**Refined write-up.**
+
+Allis's numbers are order-of-magnitude estimates (1994, before several of the listed games were solved), while the *definitions* — state-space complexity, game-tree complexity, and the solved taxonomy — are the durable contribution. H4 should therefore return a **band** verdict: "FLIPHEX lands near 10¹⁸, above Connect-Four and below Othello," not a precise ranking, and it should state the uncertainty in *both* the historical figures and our own upper bound. A ranking that hinges on one order of magnitude is not one the data can support.
+
+---
+
+## Lessons Learned
+
+This reading fundamentally changed how I think about game solving. I now distinguish between **ultra-weak**, **weak**, and **strong** solutions and recognize that these terms describe progressively stronger levels of knowledge about a game rather than differences in playing strength.
+
+I also learned that **state-space complexity** and **game-tree complexity** capture different aspects of computational difficulty. The former measures the number of reachable legal positions, whereas the latter estimates the size of the search required to solve the game. Before this reading, I tended to treat both as generic measures of "game complexity."
+
+Another important realization was the distinction between a **combinatorial count** and the **state-space complexity** defined by Allis. The current FLIPHEX estimate (~4.9 × 10¹⁷) should be interpreted as a progressively refined **upper bound**, not as the exact reachable state space.
+
+The Connect-Four case study also demonstrated that successful game solving is not purely a matter of computational power. Domain-specific **knowledge rules** can dramatically reduce the effective search space and are often as important as the search algorithm itself.
+
+Finally, I came to view Proof-Number Search not simply as an alternative to alpha-beta, but as a fundamentally different approach aimed at constructing mathematical proofs efficiently. This broadened my perspective on the design space of exact game solvers.
+
+## Failed Attempts
+
+Initially, I interpreted the current FLIPHEX state-space estimate as if it were the game's actual state-space complexity. After studying Allis, I realized that it is only an **upper bound**, obtained by incorporating structural constraints while still potentially including unreachable positions.
+
+I also assumed that solving a game was primarily a matter of exhaustive search and sufficient computational resources. The Connect-Four case study showed that this view is incomplete: domain-specific knowledge can be essential for making the search computationally tractable.
+
+Another assumption I revised was treating Allis's comparison table as a collection of exact values. The thesis makes it clear that many of the reported complexities are order-of-magnitude estimates intended for comparison rather than precise measurements.
+
+Finally, I recognized that architectural decisions for the FLIPHEX solver—such as choosing between alpha-beta, Proof-Number Search, or other approaches—should not be made while reading individual papers. These decisions should instead be revisited after completing the literature review and synthesizing the evidence across all research axes.

--- a/notes/phase2-alphazero-paper-notes.md
+++ b/notes/phase2-alphazero-paper-notes.md
@@ -1,0 +1,61 @@
+# Phase 2 — AlphaZero paper notes (study notes)
+
+**Objective.** Understand the AlphaGo Zero / AlphaZero self-play pipeline well
+enough to implement it from first principles in Axis 2 (Phase 4): PUCT MCTS with
+network priors, the self-play → train → evaluate loop, the policy/value loss, and
+the temperature schedule. This note backs adr-005 (AZ scope + network) and feeds
+`exercises/ex04_alphazero_math.md` and TIL #5.
+
+**Dates.** None — sequenced by dependency. Opened 2026-07-25.
+
+**Sources (each gets a `lit-note` companion, written before reading):**
+Silver et al. 2017 (*Mastering the game of Go without human knowledge*, Nature)
+and Silver et al. 2018 (*A general reinforcement learning algorithm…*, Science).
+The classical-search background lives in
+[phase2-game-theory-fundamentals.md](phase2-game-theory-fundamentals.md).
+
+**ADR posture.** adr-005 fixed a small factored (cell × tile × rotation) policy
+head and a compact network from first principles, flagged as the least-evidenced
+Phase 0 decision (R5). This is the phase to confront it with the papers. A
+contradiction triggers an adr-005 amendment, not a silent change.
+
+## PUCT selection in MCTS
+
+Pre-reading prompt: write the PUCT formula and identify exploitation vs prior vs
+exploration terms. How does it differ from UCB1, and why does a *perfect-
+information* game need no determinization (unlike PTCG's IS-MCTS)?
+
+## Self-play as a policy-improvement operator
+
+Pre-reading prompt: why is the MCTS visit-count policy π a strictly stronger
+training target than the network's own policy p? This is the crux of the whole
+method — state the improvement-operator argument precisely.
+
+## Network architecture and the state encoding
+
+Pre-reading prompt: for FLIPHEX, what channels does the input tensor need
+(own / opponent / empty / joker, hand bitmasks) — and crucially, does adr-003's
+inertness mean we do *not* encode per-tile rotation? Reconcile with adr-005.
+
+## The loss, training loop, and replay buffer
+
+Pre-reading prompt: derive L = (z−v)² − πᵀlog p + c‖θ‖². What buffer capacity and
+refresh fraction make sense at ~25 positions/game on a laptop GPU?
+
+## Temperature schedule and exploration
+
+Pre-reading prompt: why τ=1 early and τ→0 late? How does this interact with the
+absence of board symmetry in FLIPHEX (no data augmentation available)?
+
+## Exercise ex04 + TIL #5
+
+Pre-reading prompt: draft the ex04 derivations and the "AlphaZero in 500 lines"
+TIL skeleton here before transcribing.
+
+## Lessons Learned
+
+_(first-person, written by the author at phase close — not ghost-written)_
+
+## Failed Attempts
+
+_(first-person, written by the author at phase close — not ghost-written)_

--- a/notes/phase2-alphazero-paper-notes.md
+++ b/notes/phase2-alphazero-paper-notes.md
@@ -54,8 +54,61 @@ TIL skeleton here before transcribing.
 
 ## Lessons Learned
 
-_(first-person, written by the author at phase close — not ghost-written)_
+This phase changed what I think AlphaZero *is*. I began with "MCTS guided by a
+neural network" and ended with a closed learning system — one where search
+continuously improves the policy and value functions that will guide the next
+search. Search is not only a decision algorithm; it is also the data-generation
+mechanism.
+
+Separating the two networks was the next step. Early on I lumped them together as
+"neural guidance". They solve different problems: the policy biases exploration
+toward promising actions, while the value network replaces rollout-based
+evaluation with an estimate of the state's value under increasingly strong play.
+
+Reading AlphaGo Zero and AlphaZero side by side taught an engineering lesson as
+much as a technical one: architectural decisions are contextual, not universally
+optimal. The evaluator gate and symmetry augmentation are not features to copy —
+each has to earn its place against my compute budget, this game's properties, and
+what the experiment is trying to establish.
+
+The largest change, though, was methodological rather than algorithmic. I set out
+to implement AlphaZero for FLIPHEX; I now see the project as an experimental
+framework for understanding the game. The learner, the exact solver and the
+design hypotheses answer different questions, and their value depends on staying
+complementary rather than competing.
+
+Last, the phase reinforced a research habit: literature should challenge design
+decisions, not merely ratify them. Several ADRs predate the papers, and treating
+them as hypotheses to confront — rather than assumptions to defend — is what made
+the study worth the week.
 
 ## Failed Attempts
 
-_(first-person, written by the author at phase close — not ghost-written)_
+Several assumptions recorded in Phase 0 turned out to be incomplete or simply
+wrong.
+
+I underestimated the distance between classical UCT and AlphaZero's PUCT, filing
+the latter as a better exploration strategy. The deeper innovation is coupling
+search to learning through visit-count supervision — not swapping one exploration
+formula for another.
+
+I also read the value network as a computational optimization over rollouts. Read
+more carefully, the substantive change is *what is being estimated*: rollout
+values reflect random play, learned evaluations reflect increasingly strong
+policies. The compute saving follows from that choice; it is not the motivation
+for it.
+
+I treated board symmetry as equivalent to game symmetry. Revisiting FLIPHEX's
+state representation showed the chiral `P3-y` tile breaks the mirror for most of
+the game, which leaves AlphaGo Zero's augmentation largely inapplicable even
+though the board does carry a mirror automorphism.
+
+And I entered the phase believing that reproducing AlphaZero's architecture as
+faithfully as possible was the safe strategy. I now think it is a poor default.
+Several choices in the papers are engineering decisions taken under DeepMind's
+constraints rather than justified principles, and each should be adopted only
+where it serves this project's goals.
+
+The biggest failed assumption was that solving FLIPHEX was the point. By the end
+of the phase I understood the solver as an instrument for evaluating the game's
+design, not as the research outcome.

--- a/notes/phase2-game-theory-fundamentals.md
+++ b/notes/phase2-game-theory-fundamentals.md
@@ -1,0 +1,76 @@
+# Phase 2 — Game Theory Foundations (study notes)
+
+**Objective.** Acquire the vocabulary to reason rigorously about
+perfect-information, deterministic, zero-sum games: minimax and its proof,
+alpha-beta and its optimality, transposition tables + Zobrist hashing,
+retrograde analysis, and state-space / game-tree complexity. This note backs
+the Axis 1 (solver) and Axis 3 (complexity) design decisions and feeds
+`exercises/ex02_game_theory.md`.
+
+**Dates.** None — sequenced by dependency. Opened 2026-07-25.
+
+**Sources (each gets a `lit-note` companion, written before reading):**
+Russell & Norvig 4e Ch.5 (adversarial search); Allis 1994 (game-tree
+complexity); Schaeffer et al. 2007 (Checkers is solved — retrograde). The
+AlphaZero papers live in the companion note
+[phase2-alphazero-paper-notes.md](phase2-alphazero-paper-notes.md).
+
+**ADR posture.** The six Phase 0 ADRs were written from first principles before
+the literature pass (a conscious exception, see the roadmap's Phase 1 note). Any
+source here that contradicts an ADR triggers an **ADR amendment**, not a silent
+edit — `rules-canonical`, `board-geometry`, and `piece-archetypes` remain the
+protected documents. Watch especially adr-004 (solver approach) and adr-005
+(AZ scope) against R&N Ch.5 and the AZ papers.
+
+## Minimax on finite zero-sum perfect-information games
+
+Pre-reading prompt: what exactly does the minimax theorem guarantee, and why do
+perfect information + determinism + finiteness make FLIPHEX a clean instance?
+Where does the "zero-sum" assumption enter our engine (`rules.outcome`)?
+
+## Alpha-beta pruning and its optimality
+
+Pre-reading prompt: why does alpha-beta return the *same* root value as plain
+minimax, and where does the O(b^{d/2}) best-case come from? What is the concrete
+move-ordering signal for FLIPHEX (flip count, centre, low-arrow-first)?
+
+## Transposition tables and Zobrist hashing
+
+Pre-reading prompt: our `GameState.key()` already carries an incremental Zobrist
+hash (adr-003). What makes Zobrist O(1)-updatable per move, and what has to be in
+the key for FLIPHEX given placed tiles are inert (colour + hands + turn, never
+rotation)? What are the collision and replacement-policy pitfalls?
+
+## Retrograde analysis (endgame databases)
+
+Pre-reading prompt: Schaeffer's checkers result works backward from terminal
+positions. For FLIPHEX, what makes a position enumerable backward given the flip
+rule is not reversible? What "k pieces remaining" horizon is realistic on 5×5?
+
+## State-space and game-tree complexity
+
+Pre-reading prompt: Allis distinguishes state-space from game-tree complexity.
+Write the naive FLIPHEX upper bound and the inertness-corrected one (adr-003
+drops the 6^25 rotation factor). Where do Reversi 6×6/8×8 and Hex sit, for H4?
+
+## Exercise ex02 — game-theory problem set
+
+Pre-reading prompt: the six problems in `exercises/ex02_game_theory.md`
+(minimax theorem, alpha-beta derivation, O(b^{d/2}), TT/Zobrist, PUCT, FLIPHEX
+state-space estimate). Draft answers here first, then transcribe.
+
+## Hypothesis lock (H1–H5)
+
+Pre-reading prompt: refine each placeholder in `docs/research.md` into a
+falsifiable statement with a named test and decision rule. **Blocker: OPEN-2
+(chiral tile mirroring) must be resolved on the physical board before locking —
+it confounds H1.** Record the pre-registration rationale here; the lock itself
+is the tagged commit `v0.3-hypotheses`.
+
+## Lessons Learned
+
+_(first-person, written by the author at phase close — not ghost-written)_
+
+## Failed Attempts
+
+_(first-person, written by the author at phase close — not ghost-written)_

--- a/notes/phase2-game-theory-fundamentals.md
+++ b/notes/phase2-game-theory-fundamentals.md
@@ -69,8 +69,55 @@ is the tagged commit `v0.3-hypotheses`.
 
 ## Lessons Learned
 
-_(first-person, written by the author at phase close — not ghost-written)_
+This phase supplied the vocabulary the project was designed without. Before the
+reading I could reason intuitively about search and complexity, but I had no
+precise language in which to justify a decision. Three distinctions changed how I
+think about exact solvers: state-space against game-tree complexity, why
+alpha-beta preserves the minimax value under any move ordering, and what a
+transposition table actually buys.
+
+Feasibility, I learned, is not one quantity — it depends on which algorithm is
+doing the work. State-space size governs exhaustive enumeration and retrograde
+analysis; game-tree complexity governs forward search. I used to compare games by
+reachable-state count alone, which is why it once seemed paradoxical that a game
+with a vastly larger state space can be the easier one to solve, provided its
+branching is constrained enough.
+
+Exact solving and reinforcement learning also stopped looking like rivals. They
+answer different questions, and each becomes appropriate in a different region of
+the complexity landscape: small FLIPHEX variants yield exact ground truth by
+exhaustive methods, larger ones require approximation. That split is the
+conceptual foundation of H1 and H3.
+
+Last, I now treat architectural decisions as hypotheses rather than facts.
+Writing the ADRs before the reading turned out to be an advantage — every
+assumption had to confront the literature head-on instead of being quietly
+adjusted to fit it. Most of the decisions survived unchanged, but they carry far
+stronger justification than they did.
 
 ## Failed Attempts
 
-_(first-person, written by the author at phase close — not ghost-written)_
+Several assumptions from the project's early design did not survive this phase.
+
+I treated game complexity as a single quantity. Allis made clear that state-space
+and game-tree complexity are independent measures constraining different solution
+methods — which is exactly why ranking games by state count alone produces wrong
+conclusions about what is solvable.
+
+I underestimated what the exact solver is *for*. I had it filed as an
+implementation goal; the literature convinced me its real value is as objective
+ground truth, the thing against which approximate methods and design hypotheses
+get measured.
+
+I assumed that improving a search algorithm changes what it concludes. Alpha-beta
+showed otherwise: move ordering changes cost, not correctness. That distinction
+came back later, when reasoning about how independent the project's exact and
+approximate methods really are.
+
+And I entered the phase expecting the literature to confirm the ADRs. What it did
+instead was expose the assumptions needing stronger justification, more careful
+wording, or a narrower scope. Treating those as falsifiable claims was far more
+productive than defending them as design constraints.
+
+The most valuable outcome of this phase was not a set of new algorithms but a way
+of asking more precise questions about games.

--- a/notes/phase2-synthesis.md
+++ b/notes/phase2-synthesis.md
@@ -4,51 +4,229 @@ Questions that only make sense *across* the phase's sources. Each source's
 companion note forward-refs here with 🔄. Answer these after you have read the
 relevant pair, in first person, then I refine.
 
-Sources: R&N Ch.5 (adversarial search), Silver 2017 (AlphaGo Zero),
-Silver 2018 (AlphaZero), Allis 1994 (complexity), Schaeffer 2007 (retrograde).
+**Sources:**
+[R&N AIMA Ch.6](notes/russell-norvig-aima-ch6-adversarial-search.md) (adversarial
+search) · [Silver 2017](notes/silver-2017-alphago-zero.md) (AlphaGo Zero) ·
+[Silver 2018](notes/silver-2018-alphazero.md) (AlphaZero) ·
+[Allis 1994](notes/allis-1994-searching-for-solutions.md) (solving taxonomy and
+complexity) · [Schaeffer 2007](notes/schaeffer-2007-checkers-is-solved.md)
+(retrograde at scale).
 
-## S1 — MCTS: classical vs AlphaZero (R&N ↔ Silver 2017) 🔄
-**Prompt.** R&N Ch.5 presents MCTS with *random rollouts* for the default
-policy; AlphaGo Zero replaces rollouts with a learned value head and adds a
-network prior in selection. Line up the two selection rules (UCB1 vs PUCT) term
-by term. Why does perfect information make the learned value trustworthy enough
-to drop rollouts — and why would your PTCG (imperfect information) not permit the
-same move?
+> **Scaffold note.** This file was drafted in Phase 0 and two of its premises
+> were falsified during the reading: adversarial search is **Chapter 6** in the
+> 4th edition (it was Ch.5 in the 3rd), and the board's symmetry group is **not
+> trivial** — it is Z/2 ([adr-008](docs/adr/adr-008-board-mirror-symmetry.md)).
+> S3 has been rewritten accordingly. **S5** and **S6** are new: they are the two
+> questions the Phase 2 readings raised that no single note can settle.
+
+---
+
+## S1 — MCTS: classical UCT vs AlphaZero's PUCT (R&N §6.4 ↔ Silver 2017/2018) 🔄
+
+**Prompt.** Line up the two search procedures term by term and be precise about
+what is *substituted* versus what is *deleted*:
+
+| | R&N §6.4 (generic UCT) | AlphaZero |
+|---|---|---|
+| selection | `Q(a) + c·√(ln N / n(a))` | `Q(a) + c·P(a)·√ΣN / (1 + N(a))` |
+| leaf value | random playout to a terminal | one network call → `v` |
+| phases | 4 | ? |
+| search output | a move | ? |
+
+Three things to settle. (a) The exploration terms are not the same *kind* of
+object: UCB1's is a concentration bound (it answers "how wrong could `Q(a)`
+be?"), PUCT's is not — it decays like `1/n` instead of `√(ln n / n)` and is
+scaled by the policy prior. What is traded away, and why is that trade
+*necessary* rather than merely convenient at FLIPHEX's b₀ = 1450? (b) The
+simulation phase is **removed**, not replaced — MCTS drops to three phases. What
+was the only unbiased estimator in the algorithm, and what replaces its role in
+keeping the value estimates honest? (c) The substitution nobody lists: the visit
+counts become the **policy training target** (`π ∝ N^{1/τ}`), closing the loop
+between search and network. Without that row, AlphaZero is just guided MCTS.
+
+Then the FLIPHEX-specific question. Perfect information is what makes a learned
+value trustworthy enough to drop rollouts — the leaf's value is a function of the
+state alone, with no belief to average over. State why an imperfect-information
+game (your PTCG project) could not make the same move, and what it would have to
+do instead.
+
+**One thing FLIPHEX gets for free that is worth naming here:** R&N list two MCTS
+disadvantages, and the second — positions that are "obviously" won but need many
+playout moves to verify — is *void* for FLIPHEX. Playouts are ≤25 plies, always
+terminate, always yield a decided winner. So R&N's *early playout termination*
+machinery is unnecessary, and plain UCT is a cheap baseline. Does that change
+whether AlphaZero's rollout-free design is a *requirement* here or merely an
+inherited choice?
 
 **My take.**
 
 **Refined write-up.**
+
+---
 
 ## S2 — The evaluator gate: kept then dropped (Silver 2017 ↔ 2018) 🔄
-**Prompt.** AlphaGo Zero promotes a new network only if it beats the best in
-≥55% of games; AlphaZero removes this gate and trains a single continuously
-updated network. What changed to make the gate unnecessary, and which regime
-(gated / continuous) is safer for a *single-laptop* FLIPHEX run where compute is
-scarce and instability is costly?
+
+**Prompt.** AlphaGo Zero promotes a new network only if it beats the current best
+in ≥55% of games; AlphaZero removes the gate and trains a single continuously
+updated network. What changed to make the gate unnecessary — and be careful here,
+the honest answer involves what the gate was *protecting against* and whether
+that risk was ever measured or merely assumed.
+
+Then the decision this actually drives: which regime is safer for a
+**single-laptop** FLIPHEX run, where compute is scarce and a collapsed training
+run costs days? Note the asymmetry — the gate costs evaluation games (compute you
+do not have) but buys monotonicity (protection you cannot otherwise afford.)
+State a recommendation for [adr-005](docs/adr/adr-005-alphazero-scope-and-network.md),
+not just a comparison.
 
 **My take.**
 
 **Refined write-up.**
 
-## S3 — Symmetry: a tool AGZ has and FLIPHEX lacks (Silver 2017 ↔ board-geometry) 🔄
-**Prompt.** AGZ uses Go's 8-fold dihedral symmetry for data augmentation and
-evaluation averaging. FLIPHEX's board symmetry group is trivial. Quantify what
-this costs us: if AGZ effectively gets 8× the labelled data per game, what does
-that imply for the number of self-play games FLIPHEX needs to reach comparable
-coverage? Does this strengthen the case for the exact solver (Axis 1) as the
-cheaper source of ground truth on small variants?
+---
+
+## S3 — Symmetry: what FLIPHEX actually has, and what it is worth 🔄
+
+*(Rewritten — the original premise, "FLIPHEX's board symmetry group is trivial",
+is false.)*
+
+**Prompt.** Three positions on the same question, from three sources:
+
+- **AlphaGo Zero** exploits Go's 8-fold dihedral group for data augmentation and
+  evaluation averaging — 8× labelled data per game, free.
+- **AlphaZero** drops symmetry augmentation entirely, because chess and shogi
+  have none to exploit. Same recipe, no augmentation, still superhuman.
+- **FLIPHEX** sits between: the board's automorphism group is **Z/2** (a
+  left-right mirror across column C — [adr-008](docs/adr/adr-008-board-mirror-symmetry.md)),
+  but the chiral `P3-y` tile breaks it at the *game* level for as long as either
+  copy remains in a hand.
+
+Settle four things. (a) Why does "the board has a mirror" not imply "self-play
+gets 2× data"? Be precise about *when* the mirror is a valid game symmetry and
+what fraction of a typical game satisfies that condition. (b) Given (a), is the
+right Axis-2 design decision AGZ's (augment) or AlphaZero's (don't)? Argue it,
+then write the one-line justification adr-005 should carry. (c) The mirror *is*
+fully valid once both `P3-y` are placed — which is precisely where the retrograde
+endgame databases live ([Schaeffer note](notes/schaeffer-2007-checkers-is-solved.md)
+§2.3). So the symmetry is worth ~2× to **Axis 1** and ~0× to **Axis 2**. Is that
+inversion an accident of this game, or a general pattern (symmetries that only
+hold late help exact endgame methods, not learners)? (d) The original scaffold
+asked whether this "strengthens the case for the exact solver as the cheaper
+source of ground truth on small variants". Answer it with the corrected premise —
+and note that the answer no longer rests on symmetry at all.
 
 **My take.**
 
 **Refined write-up.**
 
-## S4 — Two routes to a game's value (Silver ↔ Schaeffer ↔ Allis) 🔄
-**Prompt.** Schaeffer *solves* checkers exactly (retrograde + search); AlphaZero
-*approximates* the optimal policy by learning. Allis frames when each is feasible
-via state-space and game-tree complexity. Place FLIPHEX on that map: for which
-variants does Axis 1 give exact truth, and where must Axis 2's learned agent take
-over? This is the intellectual spine of H1/H3 — the two axes cross-checking each
-other.
+---
+
+## S4 — Two routes to a game's value: where exactly is the boundary? (Allis ↔ Schaeffer ↔ Silver) 🔄
+
+**Prompt.** This is the intellectual spine of H1/H3. Allis frames feasibility via
+**two independent** complexity axes; the Phase 2 readings supplied the numbers to
+place FLIPHEX on both.
+
+| | state-space | game-tree | solved? |
+|---|--:|--:|---|
+| Connect Four | 10¹⁴ | — | yes |
+| Nine Men's Morris | 10¹¹ | — | yes |
+| Awari | 10¹² | — | yes |
+| Checkers | 5 × 10²⁰ | small `b` (forced captures) | **weakly**, 2007 |
+| **FLIPHEX 4×4** (adr-009 deck) | 9.3 × 10¹⁰ | ~10³³ | target: **strongly** |
+| **FLIPHEX 5×5** | 4.9 × 10¹⁷ | ~10⁶¹ | no |
+
+Answer four things. (a) Checkers has ~1000× *more* states than FLIPHEX 5×5 and
+was solved; FLIPHEX 5×5 will not be. Explain why using both axes — the
+resolution is that state-space and game-tree complexity are independent, and
+checkers is easy on the one that governs a forward proof. Name the quantity that
+actually binds FLIPHEX. (b) Draw the boundary concretely: for which variants does
+Axis 1 give exact truth (and of which Allis class — weak or strong?), and where
+must Axis 2 take over? Produce the honest headline sentence. (c) **"Draws are
+impossible" is a trade, not a gift** — it collapses the backward pass to a single
+stratified sweep (no cycles, no GHI, no fixpoint) *and* it destroys the forward
+proof's main economy, because on a two-element value set a bound *is* the value,
+so Schaeffer's "partially proven" category is empty by construction. Which side
+of that trade dominates for FLIPHEX, and does it change the boundary you drew in
+(b)? (d) H3 asks the learner to agree with the solver on shared variants. Given
+(b), on which boards is that comparison actually available, and is that enough
+evidence to carry H3?
+
+**My take.**
+
+**Refined write-up.**
+
+---
+
+## S5 — What does solving a game actually buy? (Allis §6 ↔ R&N §6.7 ↔ Schaeffer §7) 🔄
+
+*(New — this is what the [Schaeffer note](notes/schaeffer-2007-checkers-is-solved.md)
+§7.1 forward-refs.)*
+
+**Prompt.** Three sources give three different answers, and this project's thesis
+needs a fourth.
+
+- **Schaeffer §7** is upbeat: the significance is AI plus parallel computing,
+  with methods transferring to bioinformatics. The *game* is barely the point.
+- **Allis §6** ("which games will survive") reads the same act differently: a
+  solved game loses something. Solving is partly an act of *ending* a game.
+- **R&N §6.7** limitation 3: both alpha-beta and MCTS "do all their reasoning at
+  the level of individual moves", with no abstraction and no goal-directed
+  planning. A solve returns the *value*; it does not return the *why*.
+
+Now the tension this project has to face. [research.md](docs/research.md)'s thesis
+is that FLIPHEX is "a design to understand" — it wants first-player balance, the
+joker's effect, deck quality, design feedback. But a solve produces a
+win/loss verdict at the root and a lookup table. Answer: (a) does an exact 4×4
+verdict actually serve the design thesis, or does it serve a *different*, more
+conventional thesis that happens to be easier to defend? (b) H5 (deck balance)
+and H6 (counterfactual robustness) cannot be answered by a root value at all —
+what *can* the solved database tell you about them, if you query it rather than
+just read its root? (Think: distribution of values over positions, which tiles
+appear in optimal lines, how often the mirror-equivalent move is also optimal.)
+(c) Is there a version of the writeup where the exact solve is the *instrument*
+and the design findings are the *result*, rather than the solve being the result?
+Write that headline.
+
+**My take.**
+
+**Refined write-up.**
+
+---
+
+## S6 — May Axis 2 feed Axis 1? (Schaeffer §4 ↔ adr-004's independence principle) 🔄
+
+*(New — raised by the Schaeffer reading and currently unresolved in any ADR.)*
+
+**Prompt.** [adr-004](docs/adr/adr-004-solver-approach.md) rejects MCTS as the
+Axis 1 method **on principle**: "using it for Axis 1 would destroy the
+independence that makes cross-axis verification meaningful. The two axes must
+fail differently." That principle is what gives H3 its force.
+
+Schaeffer's proof tree, however, is bootstrapped by domain knowledge the project
+does not have: *"From the human literature, a single 'best' line of play was
+identified and used to guide the initial foray of the manager into the depths of
+the search tree… Without it, the manager may spend unnecessary effort looking for
+an important line to explore."* FLIPHEX has **no human literature** — no opening
+book, no expert lines. The obvious substitute is a policy from Axis 2. The same
+question arises for move ordering, on which
+[R&N §6.2.4](notes/russell-norvig-aima-ch6-adversarial-search.md) says the
+solver's whole efficiency depends.
+
+Settle where the line is. (a) Distinguish two uses sharply: Axis 2 deciding
+**what order to do exact work in** (ordering, scheduling, seeding) versus Axis 2
+supplying **values** the proof relies on. Does the first affect *correctness*?
+(Alpha-beta returns the same value under any ordering; retrograde enumeration is
+order-independent by construction.) (b) If correctness is untouched, what exactly
+*is* damaged — and is "independence" the right word for it, or is the real risk
+narrower: that a solver tuned by the learner will be *fastest exactly where the
+learner is strongest*, leaving the disagreement regions under-searched? (c)
+Propose a rule adr-004 could adopt, precise enough to implement. A candidate to
+argue for or against: *Axis 2 output may influence the order and scheduling of
+Axis 1 work, never its values or termination conditions; and any Axis-1 result
+used to validate Axis 2 must be reproducible from a run with ordering seeded
+only by Axis-1-internal heuristics.* (d) Would adopting that rule cost anything
+real, given that 4×4 is a full enumeration where ordering is irrelevant anyway?
 
 **My take.**
 

--- a/notes/phase2-synthesis.md
+++ b/notes/phase2-synthesis.md
@@ -289,26 +289,26 @@ not its full symmetry orbit. Part B measures the cost: **150 of the 1450 opening
 moves have no legal mirror image**, exactly 25 cells × 6 rotations, every one of
 them `P3-y`. The break lives in `ACTIONS(s)`, not in `s`.
 
-**"A small fraction" can be quantified.** Each player holds 13 tiles; purple
-plays all 13 (odd plies), green plays 12 of 13 (even plies). Under a
-uniform-random play order, the mirror becomes a full game symmetry only after
-*both* copies are on the board:
+**"A small fraction" can be quantified.** Purple holds 13 tiles (the 12-tile deck
+plus the joker) and plays all 13 on the odd plies; green holds 12 and plays all
+12 on the even plies ([rules-canonical.md](docs/rules-canonical.md) §2, I3/I5).
+Every tile reaches the board, so both `P3-y` copies are *always* placed — the
+mirror always becomes a game symmetry eventually, the only question is when.
+Under a uniform-random play order:
 
 | quantity | value |
 |---|--:|
-| E[fraction of plies where the mirror is a valid game symmetry] | **0.29** |
-| P(both placed by ply 16) | 0.38 |
-| P(both placed by ply 20) | 0.59 |
-| P(the mirror is *never* valid in a game) | **1/13 ≈ 7.7 %** |
+| E[fraction of plies where the mirror is a valid game symmetry] | **0.31** |
+| E[ply on which the second `P3-y` lands] | 17.2 |
+| P(both placed by ply 16) | 0.41 |
+| P(both placed by ply 20) | 0.64 |
 
-That last row is the one worth keeping: green plays only 12 of its 13 tiles, so
-roughly one game in thirteen ends with a `P3-y` still in hand and the mirror
-never becomes a symmetry at all. (Random-order estimate — the distribution under
-optimal play is unknown and could move in either direction. It is the right order
-of magnitude for a design decision, not a measurement.)
+(Random-order estimate — the distribution under optimal play is unknown and could
+move in either direction. It is the right order of magnitude for a design
+decision, not a measurement.)
 
-**(b) The decision, with the arithmetic done.** 2× on 29 % of positions is an
-effective **1.29×** in data. Against b₀ = 1450 and a laptop budget that is a
+**(b) The decision, with the arithmetic done.** 2× on 31 % of positions is an
+effective **1.31×** in data. Against b₀ = 1450 and a laptop budget that is a
 rounding error, and it is not free: every augmented sample needs a
 validity check (is `P3-y` out of *both* hands?), and augmenting one invalid
 position silently poisons the policy target with a move that does not exist.
@@ -320,9 +320,9 @@ group is trivial (adr-002)", which is **false** — adr-008 supersedes it):
 > **No symmetry augmentation.** The board has a Z/2 mirror
 > ([adr-008](docs/adr/adr-008-board-mirror-symmetry.md)), but the chiral `P3-y`
 > tile makes it a *partial* game symmetry: it is valid only once both copies are
-> placed, ~29 % of plies under random order and never at all in ~1/13 of games.
-> The available gain is ≈1.29× in data, against a per-sample validity check and a
-> silent-corruption risk if the check is wrong. Not worth it.
+> placed, ≈31 % of plies under a random play order. The available gain is ≈1.31×
+> in data, against a per-sample validity check and a silent-corruption risk if
+> the check is wrong. Not worth it.
 
 **(c) The inversion is a pattern, not an accident, and it has a mechanism.**
 Symmetries in games are broken by state components that are *consumed*: hands,
@@ -353,7 +353,7 @@ adr-008 entirely. Symmetry was never part of it.
 **On redesigning `P3-y` — I would argue against, and the section's own numbers
 are the argument.** Removing chirality would make the mirror a full game symmetry
 throughout, which buys: ≈2× data on Axis 2 (you just valued the partial version
-at 1.29× and rejected it), and ~⅓ of a k level on Axis 1. Against that,
+at 1.31× and rejected it), and ~⅓ of a k level on Axis 1. Against that,
 chirality is the **only** thing in the design that distinguishes a line of play
 from its mirror image. Remove it and every opening acquires an exactly-as-good
 twin — the strategically distinct opening set halves, and H1 becomes partly

--- a/notes/phase2-synthesis.md
+++ b/notes/phase2-synthesis.md
@@ -337,7 +337,7 @@ So the honest generalisation is: *symmetries broken by consumable state help
 exact endgame methods and not learners*, and that covers both games.
 
 **But deflate the "~2× to Axis 1" in the prompt** — it is real and it is small.
-The k-layer bounds are k ≤ 3: 9.0×10¹², k ≤ 4: 1.5×10¹⁴, k ≤ 5: 1.2×10¹⁵, i.e.
+The k-layer bounds are k ≤ 3: 9.4×10¹², k ≤ 4: 1.5×10¹⁴, k ≤ 5: 1.2×10¹⁵, i.e.
 each extra empty cell costs ~8–17×. A 2× fold buys `log 2 / log 8 ≈` **one third
 of one k level**. Worth taking, never worth designing around.
 
@@ -477,7 +477,7 @@ clause would rest on a single variant (4×4 reduced), n = 1. That is not enough 
 carry a hypothesis, and the fix is available now:
 
 - adr-009's reduced-deck policy is precisely what generates a *family* of
-  comparison points — 3×3 full deck (3.1 × 10⁹, the correctness fixture), 4×4
+  comparison points — 3×3 full deck (2.3 × 10⁹, the correctness fixture), 4×4
   reduced, and 4×4 under alternative reduced decks.
 - More importantly, the **endgame layers of the shipped 5×5** are solvable from
   the terminal end (k ≤ 4 at 1.5 × 10¹⁴ is a storage question, not a search one)

--- a/notes/phase2-synthesis.md
+++ b/notes/phase2-synthesis.md
@@ -1,0 +1,55 @@
+# Phase 2 — cross-source synthesis
+
+Questions that only make sense *across* the phase's sources. Each source's
+companion note forward-refs here with 🔄. Answer these after you have read the
+relevant pair, in first person, then I refine.
+
+Sources: R&N Ch.5 (adversarial search), Silver 2017 (AlphaGo Zero),
+Silver 2018 (AlphaZero), Allis 1994 (complexity), Schaeffer 2007 (retrograde).
+
+## S1 — MCTS: classical vs AlphaZero (R&N ↔ Silver 2017) 🔄
+**Prompt.** R&N Ch.5 presents MCTS with *random rollouts* for the default
+policy; AlphaGo Zero replaces rollouts with a learned value head and adds a
+network prior in selection. Line up the two selection rules (UCB1 vs PUCT) term
+by term. Why does perfect information make the learned value trustworthy enough
+to drop rollouts — and why would your PTCG (imperfect information) not permit the
+same move?
+
+**My take.**
+
+**Refined write-up.**
+
+## S2 — The evaluator gate: kept then dropped (Silver 2017 ↔ 2018) 🔄
+**Prompt.** AlphaGo Zero promotes a new network only if it beats the best in
+≥55% of games; AlphaZero removes this gate and trains a single continuously
+updated network. What changed to make the gate unnecessary, and which regime
+(gated / continuous) is safer for a *single-laptop* FLIPHEX run where compute is
+scarce and instability is costly?
+
+**My take.**
+
+**Refined write-up.**
+
+## S3 — Symmetry: a tool AGZ has and FLIPHEX lacks (Silver 2017 ↔ board-geometry) 🔄
+**Prompt.** AGZ uses Go's 8-fold dihedral symmetry for data augmentation and
+evaluation averaging. FLIPHEX's board symmetry group is trivial. Quantify what
+this costs us: if AGZ effectively gets 8× the labelled data per game, what does
+that imply for the number of self-play games FLIPHEX needs to reach comparable
+coverage? Does this strengthen the case for the exact solver (Axis 1) as the
+cheaper source of ground truth on small variants?
+
+**My take.**
+
+**Refined write-up.**
+
+## S4 — Two routes to a game's value (Silver ↔ Schaeffer ↔ Allis) 🔄
+**Prompt.** Schaeffer *solves* checkers exactly (retrograde + search); AlphaZero
+*approximates* the optimal policy by learning. Allis frames when each is feasible
+via state-space and game-tree complexity. Place FLIPHEX on that map: for which
+variants does Axis 1 give exact truth, and where must Axis 2's learned agent take
+over? This is the intellectual spine of H1/H3 — the two axes cross-checking each
+other.
+
+**My take.**
+
+**Refined write-up.**

--- a/notes/phase2-synthesis.md
+++ b/notes/phase2-synthesis.md
@@ -60,7 +60,86 @@ inherited choice?
 
 **My take.**
 
+After reading these works together, I realized that I had initially framed AlphaZero too narrowly. My original goal was simply to build a strong agent capable of playing FLIPHEX. The literature changed that perspective: I now see AlphaZero less as a game-playing algorithm and more as a methodology for discovering knowledge about a game.
+
+The most important conceptual shift is not the replacement of UCT by PUCT or the removal of rollouts. Those are implementation details of a broader idea. The real innovation is that search no longer exists only to choose the next move; it also generates the training signal that improves the neural network. Visit counts become the policy target, producing a feedback loop in which better search creates better training data, which in turn produces a better search procedure. Once I understood this loop, AlphaZero stopped looking like "MCTS with neural networks" and started looking like an integrated learning system.
+
+Studying the role of the policy and value networks also clarified a distinction that I had initially overlooked. The policy network does not replace exploration; it biases exploration toward promising actions. Likewise, the value network does not merely accelerate search by avoiding expensive rollouts. More importantly, it replaces evaluations based on random play with evaluations that increasingly approximate the value of a position under strong play. Computational efficiency is therefore a consequence of this design, not its only motivation.
+
+For FLIPHEX, the motivation extends beyond building a competitive agent. Because the game is original, there are no expert players, opening books, or historical games from which to derive heuristics. Self-play therefore becomes a way to investigate the game itself. Instead of asking only whether an agent can become strong, I can also ask whether the game appears balanced, whether the first player has an inherent advantage, whether stable strategic patterns emerge, or whether weak solutions seem plausible. In that sense, reinforcement learning becomes an experimental instrument for game design rather than only an optimization technique.
+
+Finally, these readings changed how I interpret the progression from classical MCTS to AlphaZero. I no longer see it simply as replacing human knowledge with learned policies. I see it as progressively replacing handcrafted evaluation procedures with a closed learning loop in which search continuously improves the model that guides future search. For an unexplored game such as FLIPHEX, that methodology is arguably more valuable than any individual architectural component.
+
 **Refined write-up.**
+
+The headline is right and it is the one most summaries miss: the substitution
+that makes AlphaZero *AlphaZero* is row four of the table — the search output is
+not a move but a distribution, `π ∝ N^{1/τ}`, which becomes the policy target.
+Without that row the system is guided MCTS. Keep it.
+
+But "the exploration term and the rollout are implementation details of a broader
+idea" is too generous, and at FLIPHEX's branching factor it is false for one of
+the two.
+
+**(a) PUCT is not a cosmetic change at b₀ = 1450.** UCB1's `√(ln N / n(a))` is
+*infinite* at `n(a) = 0`, so plain UCT is obliged to visit every child once
+before the formula distinguishes any of them. On ply 1 that is 1450 simulations
+spent enumerating, and a second 1450 before any child has two samples. PUCT's
+`√ΣN / (1 + N(a))` is finite at `N(a) = 0` and scaled by `P(a)`, so the prior
+ranks all 1450 children *before* any of them is visited.
+
+What is traded is the *kind* of guarantee. UCB1's term is a concentration bound —
+it is derived from Hoeffding and its regret guarantee is distribution-free: it
+holds whatever the game is, with no prior. PUCT's term is not a bound of
+anything; it is a decay schedule (`1/n(a)` at fixed total, against UCB1's
+`1/√n(a)`) whose only justification is that `P(a)` was roughly right. So you
+trade a distribution-free guarantee for a prior-conditional one. That trade is
+**necessary, not convenient**, because at b = 1450 a distribution-free guarantee
+needs ≫ b samples before it says anything, and a laptop search will never run
+≫ 1450 simulations per move. A guarantee you cannot afford to collect is not a
+guarantee.
+
+**(b) The rollout was the only unbiased estimator in the algorithm** — unbiased
+for the value of the leaf *under the rollout policy*, which is exactly its
+weakness and exactly why it was safe: it never claimed to know anything. Note
+what does **not** replace it. Nothing inside the search keeps `v` honest; a
+single AlphaZero search is entirely a function of a network that could be
+arbitrarily wrong. The anchoring moved *out* of the search and into the training
+loop: `v` is regressed on `z`, the actual game outcomes, so the estimates are
+kept honest across the corpus rather than within one search. Your phrase
+"increasingly approximate the value under strong play" is right; the point worth
+adding is that "increasingly" is doing structural work — early in training the
+search has no honesty mechanism at all.
+
+**The FLIPHEX consequence the take skips.** The two changes have *different*
+standing here, and conflating them would cost you a cheap baseline:
+
+| change | status for FLIPHEX |
+|---|---|
+| UCT → PUCT (prior) | **required** — b₀ = 1450 makes prior-free selection useless |
+| rollout → network `v` | **inherited**, defensible, not forced |
+
+Rollouts in FLIPHEX are ≤ 25 plies, always terminate, and always yield a decided
+winner (no draws, fixed length). R&N's second MCTS disadvantage — positions
+"obviously" won but needing many playout moves to verify — is void, and their
+early-playout-termination machinery is unnecessary. So **plain UCT with random
+playouts is a legitimate Axis-2 baseline**, costs almost nothing to build, and
+gives an absolute floor that does not depend on any network being trained
+correctly. Recommend adr-005 name it as the baseline the learned agent must beat.
+
+**Imperfect information.** The reason FLIPHEX may drop rollouts is that perfect
+information makes `v` a function of the state alone — there is no belief to
+average over. In your PTCG project a leaf is an *information set*, and a scalar
+`v(s)` evaluated at the true state is an oracle the player does not have:
+averaging it over determinizations gives strategy fusion (the search silently
+plays a different move in each world) and non-locality. The substitute is not a
+better evaluator but a different solution concept — ISMCTS over information sets,
+or a CFR-family method whose values are defined on information sets and whose
+target is an ε-Nash strategy rather than a state value. Worth recording that the
+FLIPHEX hidden-hand variant was rejected for a different reason
+([R&N note §6.5.1](notes/russell-norvig-aima-ch6-adversarial-search.md)): the
+deck is public and placements are public, so the belief state is a point mass and
+the variant is not imperfect-information at all.
 
 ---
 
@@ -81,7 +160,64 @@ not just a comparison.
 
 **My take.**
 
+After comparing AlphaGo Zero and AlphaZero, I do not interpret the removal of the evaluator gate as evidence that it became unnecessary. The papers show that AlphaZero succeeds without the gate, but they do not present an explicit experimental justification that the gate itself no longer provides value. To me, this makes its removal an engineering decision rather than a demonstrated scientific conclusion.
+
+The evaluator gate serves a clear purpose: it establishes the strongest accepted network as a moving benchmark and only promotes a challenger after it demonstrates a meaningful improvement through direct competition. This does not guarantee monotonic improvement, but it significantly reduces the risk of promoting a weaker policy and propagating that regression into future self-play data. Since reinforcement learning continually trains on data generated by the current policy, accepting a poor network affects not only one generation but also the distribution of future training examples.
+
+AlphaZero abandons this protection in favor of a simpler and more compute-efficient training pipeline. At DeepMind's scale, where thousands of TPUs, extensive experimentation, and repeated runs make occasional regressions relatively inexpensive, that trade-off is reasonable. However, I do not believe the same reasoning transfers directly to a single-laptop research project.
+
+For FLIPHEX, I would keep the evaluator gate. The game has no established human expertise, historical datasets, or external benchmark against which to measure progress. The strongest accepted network therefore becomes the only reliable reference available. Although evaluation games consume compute that could otherwise be spent on self-play, they provide confidence that apparent improvements correspond to genuine progress rather than fluctuations in training. In a setting where a failed training run may cost several days, sacrificing some compute for greater experimental stability is a worthwhile trade-off.
+
+My recommendation for ADR-005 is therefore to retain the evaluator gate during the initial stages of the project. Once the implementation, training pipeline, and evaluation methodology become well understood, its removal can be investigated as an optimization, but it should not be treated as a default inheritance from AlphaZero simply because the published system omitted it.
+
 **Refined write-up.**
+
+"The papers show that AlphaZero succeeds without the gate, but they do not
+present an explicit experimental justification" is correct, and it can be made
+stronger. The removal is **bundled**: AlphaZero simultaneously drops the gate,
+maintains a single continuously-updated network, generates self-play from that
+network rather than from a frozen best player, and reuses hyper-parameters
+instead of re-tuning them. No experiment in either paper isolates the gate. So
+the evidence available is "a system without the gate works", never "the gate was
+unnecessary" — those are different claims, and only the first is demonstrated.
+
+One correction to the framing, though. The gate was not simply *abandoned*; part
+of its function was **absorbed elsewhere**, and this matters for your
+recommendation. The gate is a coarse guard: it acts at generation granularity and
+its decision is binary. AlphaZero's continuous updating with a large replay
+buffer and a small learning rate makes each update a small perturbation of a
+policy that is already a mixture over many recent generations — a single bad
+gradient step cannot move the self-play distribution far, because most of the
+buffer predates it. So the honest statement is that AlphaZero replaced a
+**discrete, measured** guard with a **continuous, unmeasured** one. Your argument
+survives — an unmeasured guard is still unmeasured — but it is no longer "they
+removed the protection", it is "they replaced it with something whose adequacy
+they did not test".
+
+**The recommendation needs a number.** "Keep the gate" is under-specified,
+because the gate's value is entirely a function of how many evaluation games it
+runs. AGZ's 400 games are what make a 55 % threshold mean anything: at n = 400,
+two equal networks clear 55 % about 2 % of the time. At n = 100 they clear it
+**16 %** of the time — a gate that promotes noise one time in six is worse than
+no gate, because it costs compute *and* creates false confidence. So adr-005
+should say either 400 games, or an explicit relaxation (gate every k
+generations, or a lower threshold with a stated false-promotion rate) — never
+"keep the gate" with the budget left implicit.
+
+**And one trap to close now.** The cheapest imaginable gate for FLIPHEX is
+absolute rather than relative: score candidate networks against the exact values
+from the 4×4 solved database. Near-zero compute, no opponent needed, an
+objective yardstick where none otherwise exists. **Do not do it.** Selecting
+networks by agreement with the solver and then reporting agreement with the
+solver as H3's evidence is circular — the metric would be optimised directly by
+the selection procedure. This is the same boundary S6 reaches from the other
+direction (Axis 2 may not supply Axis 1's values; Axis 1 may not supply Axis 2's
+selection criterion), and it is worth stating in adr-005 explicitly, because the
+temptation is real and the flaw is invisible once the pipeline is written.
+
+Solver positions may be used freely as a *reported diagnostic* — logged, plotted,
+watched — provided no promotion, early-stopping, or checkpoint-selection decision
+reads them.
 
 ---
 
@@ -89,6 +225,11 @@ not just a comparison.
 
 *(Rewritten — the original premise, "FLIPHEX's board symmetry group is trivial",
 is false.)*
+
+> **Verification.** `scripts/check_mirror_game_symmetry.py` proves the claims used
+> below (only `P3-y` is chiral; 150/1450 opening moves have no legal mirror; the
+> mirror becomes a full game symmetry once both copies are placed).
+> `scripts/show_mirror_break.py` renders the same three facts on the board.
 
 **Prompt.** Three positions on the same question, from three sources:
 
@@ -117,7 +258,114 @@ and note that the answer no longer rests on symmetry at all.
 
 **My take.**
 
+After revisiting FLIPHEX through the lens of AlphaGo Zero, AlphaZero, and the symmetry analysis in ADR-008, I realized that I had initially been asking the wrong question. The relevant question is not whether the board is symmetric, but whether the game state preserves that symmetry throughout play.
+
+FLIPHEX illustrates this distinction particularly well. The board itself admits a left-right mirror, yet the game does not because the chiral P3-y tile breaks that correspondence while either copy remains in a player's hand. As a result, mirroring a position generally does not produce another legally equivalent game state. The board possesses a geometric symmetry, but the game temporarily does not.
+
+This changes how I interpret AlphaGo Zero's data augmentation strategy. Data augmentation is only valid when the transformation preserves the entire game dynamics, including legal actions, state transitions, and outcomes. A board automorphism alone is insufficient. Since the P3-y tile remains unplayed during much of a typical FLIPHEX game, only a small fraction of self-play positions satisfy this condition. Consequently, I do not expect symmetry augmentation to provide a meaningful increase in training data, making AlphaZero's decision to omit augmentation the more appropriate design choice for Axis 2.
+
+Interestingly, the same symmetry becomes fully available once both P3-y tiles have been placed. At that point, the remaining game state regains mirror equivalence, exactly where exhaustive endgame methods operate. This explains why the symmetry is almost irrelevant for self-play learning but still valuable for exact retrograde analysis. The distinction is therefore not between learning and solving themselves, but between the portions of the state space on which they operate.
+
+Perhaps the most interesting outcome of this analysis is that it changed how I evaluate the design of FLIPHEX itself. When the game was created, the objective was to obtain an elegant and strategically interesting piece set, not to maximize exploitable symmetries. Knowing what I know today, I would likely redesign the P3-y tile to preserve the mirror symmetry throughout the game. Not because symmetry is aesthetically desirable, but because the literature made me realize that seemingly small design decisions can directly affect the algorithms available for analyzing and learning the game.
+
 **Refined write-up.**
+
+The reframing is exactly right and it is the load-bearing sentence of the whole
+section: *the question is not whether the board is symmetric but whether the game
+preserves that symmetry*. Everything below either sharpens it or puts a number on
+it.
+
+**One phrase to correct, and it is the same one that made the diagrams confusing.**
+"Mirroring a position generally does not produce another legally equivalent game
+state" — it does. `M(s)` is always a perfectly legal, perfectly ordinary
+position, and the flip rule itself commutes with `M` in every case tested
+(`scripts/check_mirror_game_symmetry.py`, part C: `M(RESULT(s,a)) ==
+RESULT(M(s),M(a))` holds wherever `M(a)` exists, with and without `P3-y` in
+hand). What fails is not the position but the **move set**. `M` reflects an arrow
+pattern, and `P3-y`'s reflection `{N,S,NW}` is not among its six rotations and is
+not produced by any other tile at any rotation — a hex tile may be rotated but
+never turned face-down, so a tile's achievable patterns are its rotation orbit,
+not its full symmetry orbit. Part B measures the cost: **150 of the 1450 opening
+moves have no legal mirror image**, exactly 25 cells × 6 rotations, every one of
+them `P3-y`. The break lives in `ACTIONS(s)`, not in `s`.
+
+**"A small fraction" can be quantified.** Each player holds 13 tiles; purple
+plays all 13 (odd plies), green plays 12 of 13 (even plies). Under a
+uniform-random play order, the mirror becomes a full game symmetry only after
+*both* copies are on the board:
+
+| quantity | value |
+|---|--:|
+| E[fraction of plies where the mirror is a valid game symmetry] | **0.29** |
+| P(both placed by ply 16) | 0.38 |
+| P(both placed by ply 20) | 0.59 |
+| P(the mirror is *never* valid in a game) | **1/13 ≈ 7.7 %** |
+
+That last row is the one worth keeping: green plays only 12 of its 13 tiles, so
+roughly one game in thirteen ends with a `P3-y` still in hand and the mirror
+never becomes a symmetry at all. (Random-order estimate — the distribution under
+optimal play is unknown and could move in either direction. It is the right order
+of magnitude for a design decision, not a measurement.)
+
+**(b) The decision, with the arithmetic done.** 2× on 29 % of positions is an
+effective **1.29×** in data. Against b₀ = 1450 and a laptop budget that is a
+rounding error, and it is not free: every augmented sample needs a
+validity check (is `P3-y` out of *both* hands?), and augmenting one invalid
+position silently poisons the policy target with a move that does not exist.
+AlphaZero's choice is correct here, for a reason AlphaZero never had to give.
+The line adr-005 should carry, replacing the stale
+`adr-005-alphazero-scope-and-network.md:56` justification ("the board's symmetry
+group is trivial (adr-002)", which is **false** — adr-008 supersedes it):
+
+> **No symmetry augmentation.** The board has a Z/2 mirror
+> ([adr-008](docs/adr/adr-008-board-mirror-symmetry.md)), but the chiral `P3-y`
+> tile makes it a *partial* game symmetry: it is valid only once both copies are
+> placed, ~29 % of plies under random order and never at all in ~1/13 of games.
+> The available gain is ≈1.29× in data, against a per-sample validity check and a
+> silent-corruption risk if the check is wrong. Not worth it.
+
+**(c) The inversion is a pattern, not an accident, and it has a mechanism.**
+Symmetries in games are broken by state components that are *consumed*: hands,
+castling rights, en passant, ko. Consumption is monotone toward the terminal, so
+a symmetry broken by a consumable resource is **late-holding by construction**.
+Retrograde analysis is indexed *from* the terminal end, so it lives precisely
+where such symmetries hold; a learner sees whole trajectories, so it gets the
+time-average. Chess tablebases are the standing example: with pawns on the board
+only the file mirror is available, and the full 8-fold board symmetry is
+recovered exactly in the pawnless endings — the same shape as FLIPHEX's `P3-y`.
+So the honest generalisation is: *symmetries broken by consumable state help
+exact endgame methods and not learners*, and that covers both games.
+
+**But deflate the "~2× to Axis 1" in the prompt** — it is real and it is small.
+The k-layer bounds are k ≤ 3: 9.0×10¹², k ≤ 4: 1.5×10¹⁴, k ≤ 5: 1.2×10¹⁵, i.e.
+each extra empty cell costs ~8–17×. A 2× fold buys `log 2 / log 8 ≈` **one third
+of one k level**. Worth taking, never worth designing around.
+
+**(d) — unanswered above, and the answer no longer mentions symmetry.** Yes, the
+exact solver is the cheaper source of ground truth on small variants, but because
+its cost is *knowable in advance*: 4×4 reduced is 9.3 × 10¹⁰ states, a number you
+can multiply by bytes and compare to a disk before writing any code. The learner's
+cost to reach a given accuracy is unknown, and — this is the real argument —
+unknowable without an oracle, which is the thing the solver is being asked to
+provide. That asymmetry is what makes Axis 1 the reference, and it survives
+adr-008 entirely. Symmetry was never part of it.
+
+**On redesigning `P3-y` — I would argue against, and the section's own numbers
+are the argument.** Removing chirality would make the mirror a full game symmetry
+throughout, which buys: ≈2× data on Axis 2 (you just valued the partial version
+at 1.29× and rejected it), and ~⅓ of a k level on Axis 1. Against that,
+chirality is the **only** thing in the design that distinguishes a line of play
+from its mirror image. Remove it and every opening acquires an exactly-as-good
+twin — the strategically distinct opening set halves, and H1 becomes partly
+trivial for the wrong reason. That is a real design cost paid for a training
+convenience the section already valued at ≈0.
+
+The better move is to record this as a *finding*: **`P3-y`'s chirality is
+load-bearing game content, not an oversight.** And note that the instinct is
+already pre-registered as an experiment —
+[research.md](docs/research.md) H6 names the perturbation explicitly ("deck
+swaps, e.g. removing the chiral `P3-y`"). You do not have to redesign the game to
+find out; you have to run H6.
 
 ---
 
@@ -154,7 +402,92 @@ evidence to carry H3?
 
 **My take.**
 
+After reading Allis, Schaeffer, and Silver together, I realized that they are not proposing competing solutions to the same problem. Instead, they describe two fundamentally different ways of obtaining the value of a game. Exact solving computes the true value of positions whenever the state space is tractable, while reinforcement learning attempts to approximate that value when exact computation becomes infeasible. The interesting question is therefore not which approach is better, but where the boundary between them lies.
+
+Before these readings, I was tempted to compare games only by the size of their state spaces. The comparison between Checkers and FLIPHEX made me realize why that intuition is misleading. Checkers contains orders of magnitude more states than FLIPHEX 5×5, yet it was weakly solved because the quantity that limits a forward proof is not the number of states alone, but the game-tree complexity induced by the branching factor. FLIPHEX's freedom to place any remaining piece on almost any empty square creates an enormous search tree despite having a comparatively smaller state space. The limiting factor is therefore not how many positions exist, but how many continuations must be explored.
+
+This distinction naturally divides the project into two complementary regimes. Small FLIPHEX variants fall within the reach of exact methods and can provide ground truth, while larger variants require approximate methods such as AlphaZero. I no longer see this as choosing between two algorithms; I see it as choosing the appropriate methodology for each region of the complexity landscape.
+
+The absence of draws reinforces this interpretation. Eliminating draws simplifies retrograde analysis because every terminal state belongs to only one of two outcomes, allowing values to propagate cleanly backward through the state graph. At the same time, it removes much of the pruning power available to forward proofs, since proving that a position cannot lose immediately determines its value. This trade-off does not change the boundary between solving and learning, but it clarifies why exact methods remain practical only for sufficiently small variants.
+
+Perhaps the most important consequence of these readings is how they changed my interpretation of H3. I no longer see the exact solver as an alternative to reinforcement learning. Instead, I see it as the experimental reference against which the learned value function can be evaluated whenever both approaches are feasible. Once the exact solution is no longer computationally attainable, the solver has already fulfilled its role: it has validated the methodology before approximation becomes the only remaining option.
+
 **Refined write-up.**
+
+The two-axis resolution is right, and "the limiting factor is not how many
+positions exist but how many continuations must be explored" is the correct
+sentence. Three things need to be made precise before this can carry H1/H3.
+
+**(a) Name the binding quantity — and notice it is *different* for the two
+variants.** This is the finding of the section and the take stops just short of
+it.
+
+| | binds on | number | the rational method |
+|---|---|--:|---|
+| FLIPHEX 5×5 | game-tree complexity | ~10⁶¹, and ~10³⁰·⁵ even at the Knuth–Moore minimal tree `b^⌈d/2⌉ + b^⌊d/2⌋ − 1` | none — out of reach |
+| FLIPHEX 4×4 (adr-009 deck) | state count | 9.3 × 10¹⁰ states, against a tree of ~10³³ | **enumerate, do not search** |
+
+Two details make FLIPHEX's tree unusual and both are worth stating. Depth is not
+a distribution, it is a **constant**: 25 cells, exactly one placement per ply, no
+passes, no captures, so every game is exactly 25 plies. And `b` stays large
+because it is `(25 − t)` empty cells × the distinct rotations of everything still
+in hand — it decays slowly and from 1450.
+
+The consequence for 4×4 is the sentence adr-004 does not yet contain: the tree is
+10²² times larger than the table, so **4×4 is not a search problem, it is an
+enumeration problem**. Perfect move ordering still leaves ~10¹⁶·⁵ nodes at the
+Knuth–Moore limit, while the whole state space fits in ~10¹¹ entries. That
+reframes adr-004's "move ordering drives everything": ordering matters for a
+depth-limited 5×5 *agent*, and is irrelevant to the 4×4 *proof*, where the
+binding resources are storage and enumeration throughput.
+
+**Sharpen the checkers comparison.** "Small `b` because of forced captures" is
+true but incomplete; the deeper property is the one your own Schaeffer *Lessons
+Learned* already names — **convergence**. Captures are irreversible, so the state
+graph funnels into a small endgame family that retrograde analysis can close
+once, and the forward proof only has to *reach* it. FLIPHEX has no analogue. The
+layer profile is a **hump**, not a funnel — it peaks at t = 15 filled
+(1.09 × 10¹⁷, 22 % of all states) and collapses to 3.36 × 10⁷ at t = 25 — and
+because `k` empty cells is rigidly equivalent to ply 25 − k, there is no *early*
+convergence to exploit: you cannot reach the narrow region sooner by playing
+well. That, not the state count, is the structural difference from checkers.
+
+**(b) The headline sentence:**
+
+> FLIPHEX 4×4 with the adr-009 reduced deck admits a **strong** solution by
+> retrograde enumeration of its 9.3 × 10¹⁰ states; FLIPHEX 5×5 admits neither a
+> strong nor a weak solution, because at b₀ = 1450 over a fixed depth of 25 even
+> a perfectly ordered forward proof faces ~10³⁰ nodes. The 5×5 is Axis 2's
+> exclusively, except for the endgame layers, which Axis 1 can reach from the
+> terminal end.
+
+**(c) Your answer is right; here is the sharper reason.** The no-draw trade only
+bites where the method is a *forward proof* — that is where a two-element value
+set collapses Schaeffer's "partially proven" category and destroys the partial-
+proof economy. 4×4 is an enumeration and has no forward proof; 5×5 is out of
+reach on branching whether or not the economy exists. So the trade lands entirely
+in a regime FLIPHEX never enters. The boundary in (b) is unchanged — not because
+the trade is minor, but because it is **inapplicable**. Worth recording in
+adr-004 as a trade nonetheless, so the reasoning is not rediscovered later.
+
+**(d) — and this is the one pre-lock action the section produces.** "The solver
+is the reference whenever both are feasible" is right in principle. Ask where
+that is actually true, and the answer today is: **one board**. H3's cross-axis
+clause would rest on a single variant (4×4 reduced), n = 1. That is not enough to
+carry a hypothesis, and the fix is available now:
+
+- adr-009's reduced-deck policy is precisely what generates a *family* of
+  comparison points — 3×3 full deck (3.1 × 10⁹, the correctness fixture), 4×4
+  reduced, and 4×4 under alternative reduced decks.
+- More importantly, the **endgame layers of the shipped 5×5** are solvable from
+  the terminal end (k ≤ 4 at 1.5 × 10¹⁴ is a storage question, not a search one)
+  and give solver-vs-learner comparison **on the real game**, not only on a toy.
+  That is a qualitatively stronger datapoint than any reduced board, and H3 as
+  currently worded does not claim it.
+
+Recommend H3 be reworded before `v0.3-hypotheses` to name its comparison set
+explicitly — the reduced boards *and* the 5×5 endgame layers — rather than
+saying "shared variants" and leaving the count to be discovered in Phase 5.
 
 ---
 
@@ -190,7 +523,65 @@ Write that headline.
 
 **My take.**
 
+After reading Allis, Russell & Norvig, and Schaeffer together, I realized that I had initially assigned the wrong role to the exact solver. My original goal was to solve FLIPHEX 4×4 and report whether the first player wins. The readings convinced me that this result, by itself, says surprisingly little about the quality of the game's design.
+
+An exact solution provides the value of every position, but it does not explain why those values arise or what strategic principles they reveal. As Russell & Norvig point out, search algorithms reason at the level of individual moves rather than abstractions. The solved database therefore answers "what is optimal?" but not "what makes it optimal?". The interesting knowledge emerges only after querying the database, identifying recurring patterns, and constructing higher-level explanations from those observations.
+
+This perspective also reconciles the apparently conflicting views of Allis and Schaeffer. Schaeffer is right that solving a game advances AI and produces techniques that transfer beyond games. Allis is also right that solving can diminish the game itself by replacing exploration with certainty. For FLIPHEX, however, neither outcome is the primary objective. The solved game is not the final product; it is an instrument for studying the game's design.
+
+Seen this way, the exact solution becomes much more valuable than a single win/loss verdict at the initial position. It allows questions that directly support the project's hypotheses: How balanced is the deck? Which pieces appear most often in optimal lines? Which opening moves dominate? How sensitive are optimal strategies to small rule changes? How frequently do symmetric choices remain equally good? These questions cannot be answered by the root value alone, but they can be answered by systematically interrogating the solved state space.
+
+This changed how I interpret the role of H5 and H6. Their purpose is not to prove that FLIPHEX is solved, but to use the solved variants as experimental laboratories for understanding the consequences of design decisions. The strongest contribution of the exact solver is therefore methodological rather than computational: it transforms intuition about game design into hypotheses that can be tested against complete, objective ground truth.
+
 **Refined write-up.**
+
+This is the strongest of the six, and the reconciliation of Allis against
+Schaeffer is exactly right: they disagree about what solving *costs*, not about
+what it *is*. Three additions.
+
+**One asymmetry worth naming, because it works in your favour.** Allis §6's
+argument that solving diminishes a game presupposes a game people play — the loss
+is to a community of players, and it is real for checkers. FLIPHEX has no player
+base, no opening theory, and no literature. There is nothing to diminish. That is
+not a small point: it means the usual argument *against* solving a game does not
+apply here, and it is a reason to solve FLIPHEX **now**, while the cost of
+certainty is zero. Worth one sentence in the writeup, because a reader who knows
+Allis will expect the objection.
+
+**(c) The headline you were asked for:**
+
+> The exact solve is the instrument, not the result. FLIPHEX 4×4 is solved in
+> order to *measure* an original game's design — first-player advantage, deck
+> balance, the joker's effect, and the robustness of all three under bounded
+> perturbation — against complete ground truth rather than against play.
+
+**(b) The queries have to be specified now, not in Phase 5.** This is the part
+the take reaches conceptually and does not yet make actionable, and it has a
+deadline: the database's *index* is determined by which queries it must answer.
+If it is stored keyed only by position → value, several of these become a full
+re-scan; if it carries ply and hand as index dimensions, they are lookups.
+Concretely:
+
+| hypothesis | what the root value gives | what the *database* gives |
+|---|---|---|
+| **H1** | one bit | the fraction of positions at each ply `t` won by the player to move — a **curve**. Answers whether first-player advantage is structural from ply 1 or is manufactured at some phase. |
+| **H5** | nothing | **tile criticality**: for each archetype, the fraction of positions where removing it from the hand changes the game value. This is a far stronger notion of "well-balanced deck" than placement frequency in self-play, and it is unavailable to Axis 2 at any sample size. |
+| **H6** | sign only | solve once per perturbed deck and compare the **curves**, not just whether the sign held. A design whose advantage curve keeps its shape under perturbation is robust in a way a preserved sign does not show. |
+| **S3 ↔ S5** | — | on positions where the mirror *is* a valid game symmetry, the fraction of moves whose mirror image is equally optimal. That is a direct measurement of how much strategic content `P3-y`'s chirality actually buys — the empirical answer to the redesign question S3 argues about analytically. |
+
+The last row is a genuine experiment and should be registered in
+[`experiments/registry.md`](experiments/registry.md) before Phase 5 rather than
+invented once the data exists.
+
+**One consequence for [research.md](docs/research.md).** If different hypotheses
+get different *kinds* of answer — exact value, statistical estimate with a CI,
+structural argument — then the Verdicts table needs an **evidence class** column,
+otherwise a reader cannot tell an enumerated fact from a 20-seed win rate. That
+is precisely the distinction your R&N *Lessons Learned* identified as essential
+("exact search supports claims about game-theoretic value; learned agents support
+claims about playing strength"), and the table as it stands erases it. Also note
+the table has rows H1–H5 only — **H6 has no row**, which should be fixed at the
+lock whether or not H6 is kept.
 
 ---
 
@@ -230,4 +621,76 @@ real, given that 4×4 is a full enumeration where ordering is irrelevant anyway?
 
 **My take.**
 
+After reading Schaeffer alongside the methodological principle established in ADR-004, I realized that the notion of "independence" between the two axes needs to be stated more precisely. The real distinction is not whether Axis 2 influences Axis 1, but *how* it does.
+
+There is a fundamental difference between using a learned policy to prioritize work and using it to justify conclusions. If the policy only influences move ordering, task scheduling, or the order in which states are explored, the exact algorithm still performs the same proof and eventually reaches the same result. Correctness is unchanged; only computational efficiency is affected. In contrast, if learned values influence the proof itself—by replacing exact evaluations, pruning branches without proof, or terminating the search early—the correctness of the exact method becomes dependent on an approximate one. At that point, Axis 1 ceases to be an independent source of evidence.
+
+This distinction also changed how I interpret H3. The value of cross-axis validation is not merely that two different algorithms agree, but that they agree despite relying on fundamentally different sources of evidence. If the exact solver has been optimized using information derived from the learner, agreement becomes less informative because the two methods are no longer entirely independent. The risk is therefore not incorrectness, but weaker experimental evidence.
+
+For FLIPHEX, however, this concern is largely theoretical for the 4×4 variant. Since the solver performs a complete state-space enumeration, ordering has essentially no impact on the final result. Nevertheless, I believe ADR-004 should preserve the stricter methodological rule because it generalizes naturally to larger variants and makes the experimental design easier to defend. Axis 2 may accelerate the exact solver by influencing the order of computation, but it should never contribute values, proof obligations, or termination criteria. Any exact result used to validate the learner should remain reproducible using only Axis-1-internal heuristics.
+
+More broadly, this discussion reinforced a principle that extends beyond FLIPHEX. Independent methods are valuable not because they avoid sharing ideas, but because they fail for different reasons. Preserving that difference makes agreement between them substantially stronger evidence than agreement between two systems built upon the same assumptions.
+
 **Refined write-up.**
+
+The ordering-versus-values distinction is the right cut and the closing line —
+independent methods matter because they *fail differently*, not because they
+share nothing — is the sentence adr-004 should quote. Two refinements, one of
+which changes the rule you would adopt.
+
+**(b) "Independence" is the wrong word, and naming the right one tells you when
+the rule actually matters.** Correctness is untouched: alpha-beta returns the
+same value under any ordering, and retrograde enumeration has no ordering to
+corrupt. What is damaged is not independence of *methods* but independence of
+**error**. And the concrete failure mode is narrower than "weaker evidence": a
+solver whose search order is seeded by the learner finishes *fastest exactly on
+the lines the learner already plays well*. If the Axis-1 run then stops on a
+budget — a compute cap, a partial endgame database, a depth limit — the positions
+that got resolved are a biased sample, over-representing precisely the region
+where agreement was structurally guaranteed. The risk is **selection bias**, and
+it exists **only when the Axis-1 run is incomplete**. A run that terminates by
+exhaustion cannot be biased by its own order, because order does not survive into
+the output.
+
+That is a useful sharpening, because it means the blanket rule is stronger than
+necessary and the conditional rule is exactly as strong as it needs to be.
+
+**(c) The implementable version.** Three clauses, and the implementation is two
+metadata fields plus a filter:
+
+> **R1.** Any Axis-1 result cited as ground truth for H1, H2, or H3 must come
+> from a run that terminated by **exhaustion**, not by a budget. Exhausted runs
+> are order-invariant, so Axis-2 seeding of their order is harmless *by
+> construction* and needs no prohibition.
+>
+> **R2.** Any Axis-1 run that terminates on a budget — the depth-limited 5×5
+> agent, a partial endgame database, a capped proof — must use Axis-1-internal
+> ordering only (iterative deepening, TT move, killer/history), and carries that
+> restriction as a recorded property of the artefact.
+>
+> **R3.** Every Axis-1 artefact records `ordering: internal | az-seeded` and
+> `termination: exhausted | budget`. H3's comparison set is defined as the
+> artefacts satisfying R1, and that filter is applied *before* any comparison is
+> computed, not after seeing the results.
+
+R3 is what makes R1 and R2 auditable rather than aspirational: without the
+recorded fields, "we did not seed it" is a claim in prose, and the point of
+pre-registration is that it should be a claim in the artefact.
+
+**(d) The cost — and one correction.** For 4×4, zero: enumeration has no ordering
+degrees of freedom, so the rule is **vacuous today**, which is the best possible
+time to adopt it (no result is affected, no habit has formed). But the blanket
+version the take endorses — "Axis 2 may influence order but never values" applied
+to *all* Axis-1 work — does cost something real: it would forbid the depth-limited
+5×5 alpha-beta agent from using a learned policy for move ordering, where
+[R&N §6.2.4](notes/russell-norvig-aima-ch6-adversarial-search.md) says almost all
+of the speed lives. R2 permits it, because that agent is a **player, not a
+proof** — it is never cited as ground truth, so nothing it produces enters H3.
+Scoping the rule to proof-producing runs rather than to Axis 1 as a whole is the
+one change I would make to the take's recommendation.
+
+**Cross-ref, read backwards.** The same rule forbids the mirror-image
+contamination: Axis 1's solved values may not be used as Axis 2's checkpoint
+selection criterion (S2). The general form is one sentence, and it is what
+adr-004 should carry: *neither axis may be used to select or terminate the other
+along the dimension on which they are later compared.*

--- a/notes/phase2-thesis-reframe-proposal.md
+++ b/notes/phase2-thesis-reframe-proposal.md
@@ -1,0 +1,77 @@
+# Phase 2 — proposal: reframe the thesis around computational game-design analysis
+
+**Status:** proposal, for discussion before the hypotheses lock (`v0.3-hypotheses`).
+Freely editable. Changing `docs/research.md`'s thesis is ADR-gated, so this note
+is the draft that feeds that decision — nothing here is locked yet.
+
+**Origin.** Emerged from reading Silver 2018 (AlphaZero) and reflecting that the
+project's centre of gravity could shift from *"apply AlphaZero to an original
+game"* to *"use self-play (and the exact solver) as a computational tool to
+analyse and validate an original game's design."* See
+[notes/silver-2018-alphazero.md](silver-2018-alphazero.md) §2.1/§4.2 and the
+author's reading TODOs.
+
+## The shift, in one line
+
+- **Current framing:** build a solver + an AlphaZero agent + complexity metrics
+  *for* FLIPHEX; strong play is the deliverable.
+- **Proposed framing:** treat self-play and the solver as a **methodology for
+  understanding an original game** — its balance, first-player advantage, board
+  geometry, tile distribution, and strategic depth. Strong play becomes the
+  *means*; the *understanding of the design* is the deliverable.
+
+## Why it is stronger (and honest about why)
+
+- **Novelty / portfolio.** "I implemented AlphaZero on a board game" is a
+  well-trodden exercise. "I used self-play + exact search to characterise the
+  design of an original, IP-owned game that had never been analysed" is rarer and
+  more defensible as a research contribution.
+- **It is not a pivot.** H1 (first-player advantage), H2 (joker balance), and H5
+  (archetype balance) are *already* game-analysis questions. The reframe just
+  promotes them from side-questions to the **spine** and states the unifying
+  thesis explicitly.
+- **It fits the two-axis design.** The solver gives exact truth on small variants;
+  self-play gives strong policy on the full game; complexity situates FLIPHEX
+  among known games. All three already point at "understand the game," not
+  "beat a benchmark."
+
+## Guardrails (so this elevates instead of ballooning)
+
+1. **Analyse / validate, not redesign.** The physical FLIPHEX is a USP artifact
+   on display and the author's IP. The compelling story is *validating* the
+   design, not changing it. Frame variants (alt tile distributions, alt
+   geometries, rule tweaks) as a **stretch** that tests robustness of the
+   findings — never the spine.
+2. **Existing design first.** Fully characterise the shipped 5×5 game before any
+   variant. A variant matrix multiplies experiments and directly threatens the
+   registered compute-budget risk.
+3. **Keep a fixed benchmark.** Agent-strength evaluation (Elo vs baselines) stays
+   — you still need a stable target to measure learning against. The reframe
+   *adds* design-analysis outputs; it does not remove strength measurement.
+4. **Respect the ADR gate.** This changes `docs/research.md`'s thesis, so it is
+   decided at the hypotheses lock, deliberately, not edited in silently.
+
+## Concrete changes to the hypotheses (proposed)
+
+| ID | Change | Rationale |
+|---|---|---|
+| **H1** first-player advantage | **Keep, promote to spine.** | Already the core design question; now explicitly central. Note: adr-008's mirror does **not** help here (it preserves the mover), so H1 stays a computational question. |
+| **H2** joker balance | **Keep, promote to spine.** | A design-balance question by nature. |
+| **H3** AZ convergence + solver agreement | **Keep scope, make rigour explicit.** Add: ≥5 seeds, Wilson/bootstrap CIs, variance across runs. | This rigour is already *latent* in H3's wording; make it a stated requirement. Do **not** overload H3 with game-property analysis — that is H1/H2/H5's job. |
+| **H4** complexity vs known games | **Keep.** | Situates the game; unchanged. |
+| **H5** archetype distribution well-designed | **Keep, promote to spine.** | The clearest "is the design good?" hypothesis. |
+| **H6 (new, optional / stretch)** | *"The board's mirror symmetry (adr-008), conditional on OPEN-2, yields a measurable self-play sample-efficiency gain (≈2× augmentation)."* | Turns the adr-008 finding into a testable claim. Mark optional so it does not gate the lock. |
+
+## Blocking dependency (unchanged, now doubled)
+
+**OPEN-2 must resolve before the lock.** It was already required (chiral seat
+asymmetry confounds H1). Per [adr-008](../docs/adr/adr-008-board-mirror-symmetry.md)
+it now *also* decides whether the game inherits the board's mirror (and hence H6
+and the augmentation/canonicalisation payoffs). One physical check settles both.
+
+## If accepted
+
+- Rewrite the thesis paragraph and Research Question in `docs/research.md` around
+  computational game-design analysis.
+- Lock H1–H5 (+ optional H6) with the rigour notes above at `v0.3-hypotheses`.
+- Record the thesis change via ADR (research.md is protected).

--- a/notes/russell-norvig-aima-ch6-adversarial-search.md
+++ b/notes/russell-norvig-aima-ch6-adversarial-search.md
@@ -43,8 +43,8 @@ for 6.5/6.6 unless something jumps out.
 - `exercises/` — the alpha-beta move-ordering and TT derivations land here.
 
 **Legend.** Prompts marked 🔄 need synthesis with another source — answer them in
-[phase2-synthesis.md](notes/phase2-synthesis.md) (esp. **S4**: exact solving vs
-learned play), not here.
+[phase2-synthesis.md](notes/phase2-synthesis.md) (esp. **S1**: UCT vs PUCT, and
+**S4**: exact solving vs learned play), not here.
 
 **Reading material** (extracted via `paper-study`, gitignored under
 `notes/sources/`).
@@ -620,7 +620,7 @@ rewards in [0, 1]; treat it as a starting point to tune, not a number to copy.
 **Prompt.** R&N's MCTS uses *random* (or lightly-guided) playouts and UCB1.
 AlphaZero (Silver 2018, your note) replaces playouts with a **learned value
 head** and UCB1 with **PUCT** (prior P(a) from the policy head, no rollouts).
-List the exact substitutions. This is the crux of **synthesis S4** — answer the
+List the exact substitutions. This is the crux of **synthesis S1** — answer the
 comparison in [phase2-synthesis.md](notes/phase2-synthesis.md), and here only
 note the one-line mapping. Which of FLIPHEX's Axis-2 design choices (adr-005) are
 already visible, in embryo, in R&N's generic MCTS?

--- a/notes/russell-norvig-aima-ch6-adversarial-search.md
+++ b/notes/russell-norvig-aima-ch6-adversarial-search.md
@@ -1,0 +1,859 @@
+# Reading companion — Russell & Norvig, AIMA §6: Adversarial Search and Games
+
+**Citation.** Russell, S. & Norvig, P. (2021). *Artificial Intelligence: A
+Modern Approach*, 4th ed. (Global Edition), **Chapter 6 — Adversarial Search and
+Games**, pp. 192–225. Pearson. Read from the sliced local copy
+(`refs/russell-norvig-ch6-adversarial-search.pdf`, 32 pp).
+
+> **Edition note.** In the 3rd edition (and its PT-BR translation) adversarial
+> search is **Chapter 5, "Busca Competitiva"**; the 4th edition renumbered it to
+> **Chapter 6** (Chapter 5 there is Constraint Satisfaction). Same material,
+> plus a new §6.4 on Monte Carlo Tree Search that did not exist in the 3rd ed.
+
+**Why this source, and where it sits.** This is the **textbook foundation for
+Axis 1** — the vocabulary and algorithms behind [adr-004](docs/adr/adr-004-solver-approach.md):
+minimax, the game-theoretic value, **alpha-beta pruning** with move ordering and
+transposition tables, and — critically — **Monte Carlo Tree Search** (§6.4),
+which is the bridge to Axis 2's AlphaZero ([adr-005](docs/adr/adr-005-alphazero-scope-and-network.md)).
+Read it **after** Silver 2018 (you already have PUCT/MCTS in mind, so §6.4 reads
+as "the generic MCTS that AlphaZero specialises") and alongside Allis 1994 (which
+gave the *solving* taxonomy; this gives the *search* that realises it). It closes
+the exact-solving loop the Allis note opened.
+
+**Directed reading.** The FLIPHEX-relevant core is **§6.1–6.4** and **§6.7**.
+FLIPHEX is deterministic and perfect-information ([adr-001](docs/adr/adr-001-perfect-information-scope.md)),
+so **§6.5 (Stochastic Games)** and **§6.6 (Partially Observable Games)** are
+*out of scope* — skim for one paragraph each and move on. Do not write My-takes
+for 6.5/6.6 unless something jumps out.
+
+**Cross-refs this reading feeds:**
+- [adr-004](docs/adr/adr-004-solver-approach.md) — minimax, alpha-beta + TT, move
+  ordering. This chapter is the primary reference behind the whole decision; any
+  slip in the ADR's search vocabulary gets corrected here.
+- [adr-005](docs/adr/adr-005-alphazero-scope-and-network.md) — §6.4 MCTS is what
+  AlphaZero's PUCT search is a variant of.
+- [adr-001](docs/adr/adr-001-perfect-information-scope.md) — the reason §6.5/§6.6
+  are out of scope.
+- [research.md](docs/research.md) — H1 (game-theoretic value / first-player win),
+  H3 (solver as the oracle the learned agent is checked against).
+- [allis-1994 note](notes/allis-1994-searching-for-solutions.md) — the "solved"
+  taxonomy this chapter's algorithms *produce*.
+- [silver-2018 note](notes/silver-2018-alphazero.md) — PUCT as a specialisation
+  of §6.4's UCT.
+- `exercises/` — the alpha-beta move-ordering and TT derivations land here.
+
+**Legend.** Prompts marked 🔄 need synthesis with another source — answer them in
+[phase2-synthesis.md](notes/phase2-synthesis.md) (esp. **S4**: exact solving vs
+learned play), not here.
+
+**Reading material** (extracted via `paper-study`, gitignored under
+`notes/sources/`).
+[manifest](sources/russell-norvig-ch6-adversarial-search/manifest.json) ·
+sections under
+[`sources/russell-norvig-ch6-adversarial-search/sections/`](sources/russell-norvig-ch6-adversarial-search/sections/).
+**Section ↔ prompt map** (the book's 4th-ed numbering differs from this note's §):
+
+| This note's prompt | Extracted section(s) |
+|---|---|
+| §6.1 (formal setup, zero-sum, ply) | §1 `6.1.1 Two-player zero-sum games`; ply also in §2/§3 |
+| §6.2 (minimax) | §2 `6.2`, §3 `6.2.1 minimax algorithm` |
+| §6.3 (alpha-beta core) | §5 `6.2.3 Alpha–Beta`, §6 `6.2.4 Move ordering`, §7–8 `6.3/6.3.1 Eval`, §9 `6.3.2 Cutting off`, §10 `6.3.3 Forward pruning`, §11 `6.3.4 Search vs lookup` |
+| §6.4 (MCTS) 🔄 | §12 `6.4 Monte Carlo Tree Search` |
+| §6.5/§6.6 (out of scope) | §13–18 — skim only |
+| §6.7 (limitations) | §19 `6.7 Limitations`, §20 `Summary`, §21 `Bibliographical Notes` (the checkers/AlphaGo citations feed prompt 6.7.2) |
+
+> Note: alpha-beta is **§6.2.3** and move ordering **§6.2.4** in this edition
+> (both under 6.2), not a separate 6.3 — the topics still match this note's §6.3.
+
+---
+
+## §6.1 — Game theory (the formal setup)
+
+### 6.1.1 — The formal definition of a game, matched to FLIPHEX
+**Prompt.** Write R&N's formal components of a game (S₀, TO-MOVE, ACTIONS,
+RESULT, IS-TERMINAL, UTILITY). Map each onto FLIPHEX's engine: what are FLIPHEX's
+`ACTIONS(s)` (recall 1450 on ply 1), its `RESULT` (place + one-shot flip), its
+`IS-TERMINAL` (board full at ply 25), its `UTILITY` (±1, since draws are
+impossible)? Predict before reading: does R&N define **zero-sum** and
+**game-theoretic value** with the same words the Allis note used for "solved"?
+
+**My take.**
+
+The chapter models a deterministic, perfect-information, two-player game as a search problem defined by a small set of formal components:
+
+- **Initial state (S₀):** the starting position from which play begins.
+- **TO-MOVE(s):** a function specifying which player acts in state *s*.
+- **ACTIONS(s):** the set of legal moves available in state *s*.
+- **RESULT(s, a):** the successor state obtained after applying action *a* to state *s*.
+- **IS-TERMINAL(s):** a predicate indicating whether no further actions are available because the game has ended.
+- **UTILITY(s, p):** a numerical payoff assigned to terminal states, measured from the perspective of player *p*.
+
+Russell and Norvig explicitly frame adversarial search around **two-player, deterministic, zero-sum games with perfect information**. Under these assumptions, one player's gain is exactly the other player's loss, allowing the game to be represented by a single utility function rather than independent objectives.
+
+For FLIPHEX, the mapping is direct:
+
+- **S₀:** the empty 5×5 board before any move.
+- **TO-MOVE(s):** alternates deterministically between the two players.
+- **ACTIONS(s):** every legal placement on an empty cell together with its associated one-shot flip decision. Consequently, the branching factor is state-dependent and reaches approximately 1,450 legal actions at the initial position.
+- **RESULT(s, a):** produces the next board position by placing the chosen piece and immediately applying the selected one-shot flip, after which the resulting state is fixed.
+- **IS-TERMINAL(s):** true once all 25 board positions have been filled, since no further legal actions remain.
+- **UTILITY(s, p):** a terminal payoff of +1 for a win and −1 for a loss. Because draws are impossible under the game's rules, no zero-valued outcome is required.
+
+The chapter defines **zero-sum** in essentially the same sense used in Allis's work: the interests of the two players are exactly opposed, so maximizing one player's utility necessarily minimizes the other's. However, the emphasis differs. Russell and Norvig use this property to justify the minimax formulation of adversarial search, whereas Allis employs the same game-theoretic assumptions to define what it means for a game to be *solved* and to characterize the game-theoretic value of the initial position. Thus, the underlying mathematical model is consistent across both sources, although their objectives differ: search versus solution.
+
+**Refined write-up.**
+
+The six components and the search-vs-solution reading are right. One mapping is
+wrong, and it is the load-bearing one.
+
+**`ACTIONS(s)` contains no flip decision.** You wrote "every legal placement on
+an empty cell together with its associated one-shot flip decision." There is no
+flip decision in FLIPHEX. An action is exactly a triple **(cell, tile, rotation)**;
+the arrows then fire *deterministically* on placement ([adr-003](docs/adr/adr-003-piece-representation.md),
+[adr-006](docs/adr/adr-006-no-chain-reaction.md)). That is precisely where the
+1450 comes from: 25 cells × 58 distinct (tile, rotation) pairs — not 25 × 58 × 2.
+The experiment you described earlier — placing a tile far from the others so that
+nothing flips — is a *placement* choice, not a flip choice: you steer the flips by
+choosing **where and at what rotation**, never by opting out. This matters beyond
+bookkeeping. If a flip were a free choice, it would sit in `ACTIONS`; because it
+is a consequence, it sits in `RESULT`, and `RESULT` stays a total deterministic
+function — which is the precondition for both the Zobrist TT (§6.3.2) and the
+retrograde databases (§6.3.3).
+
+Two smaller precisions. (1) R&N's `UTILITY(s, p)` is indexed by player, and
+zero-sum is the *statement* `UTILITY(s, MAX) = −UTILITY(s, MIN)`; that identity is
+what licenses collapsing two objectives into one minimax recursion. (2) The state
+FLIPHEX must carry is not only the board — it is (colouring, both hands), because
+flips detach a cell's colour from whoever placed it. R&N's `S₀`/`RESULT` covers
+this implicitly, and it is exactly the term that pushes the reachable bound from
+3²⁵ ≈ 8.5 × 10¹¹ up to 4.9 × 10¹⁷ ([research.md](docs/research.md)).
+
+Your prediction was half-right in an interesting way. R&N and Allis share the
+model (deterministic, perfect-information, zero-sum) and R&N's minimax value *is*
+Allis's game-theoretic value. But R&N have **no ultra-weak / weak / strong
+vocabulary at all** — that taxonomy is Allis's contribution and does not appear in
+this chapter. So the two sources are not redundant: R&N supply the algorithm,
+Allis supplies the standard by which its output is graded. That division is worth
+keeping explicit when H1's verdict is finally worded.
+
+### 6.1.2 — Ply, and the fixed-depth peculiarity
+**Prompt.** R&N define *ply* and discuss game length. FLIPHEX has a **fixed**
+depth of 25. Which of the chapter's later complications (iterative deepening,
+horizon effects, quiescence) are *dissolved* by a fixed, shallow depth, and which
+still bite? Note the ones to raise in the adr-004 context.
+
+**My take.**
+
+I understand *ply* as a single move made by one player. Consequently, the depth of a game tree is naturally measured in plies rather than complete turns. Russell and Norvig emphasize this distinction because search algorithms reason about individual decision points, regardless of which player is to move.
+
+For FLIPHEX, the game has a fixed maximum depth of 25 plies because exactly one board position is filled on each move and the game ends when the 5×5 board is full. Unlike games such as chess or Go, the search depth is therefore known a priori and does not vary across games.
+
+This fixed and relatively shallow depth eliminates some of the challenges that motivate approximation techniques in larger games. In particular, iterative deepening is no longer required to progressively approach the true game-theoretic value simply because the full game tree exceeds the search horizon; if sufficient computational resources are available, the complete game can, in principle, be searched directly. Likewise, classical horizon effects arising solely from arbitrary depth cutoffs disappear when the search reaches the true terminal states rather than relying on truncated evaluation. For the same reason, quiescence search—which extends unstable leaf positions beyond a cutoff to avoid misleading evaluations—is not inherently necessary in an exact search of the complete 25-ply game.
+
+However, a fixed depth does not eliminate the combinatorial explosion caused by the branching factor. With approximately 1,450 legal actions at the initial position, exhaustive minimax remains computationally infeasible despite the shallow depth. Therefore, techniques that reduce the effective search effort—particularly alpha-beta pruning, high-quality move ordering, and transposition tables—remain essential. These techniques address the width of the search tree rather than its depth.
+
+In the context of ADR-004, I therefore distinguish between depth-management techniques and search-efficiency techniques. The former become largely unnecessary when performing complete search over a fixed-depth game, whereas the latter remain central because the dominant challenge is the enormous branching factor rather than an unbounded search horizon.
+
+**Refined write-up.**
+
+The depth-vs-width framing is the right axis, and "FLIPHEX is a width problem, not
+a depth problem" is the sentence to keep. Three corrections, one of which reverses
+your conclusion.
+
+**Iterative deepening is not dissolved — it is repurposed, and R&N say so in this
+very chapter.** You treated ID as a device for approaching the game value when the
+tree exceeds the horizon. That is its §3 role. In §6.2.4 R&N give it a second,
+independent job: *"it could come from previous exploration of the current move
+through a process of iterative deepening. First, search one ply deep and record
+the ranking of moves based on their evaluations. Then search one ply deeper, using
+the previous ranking to inform move ordering… The increased search time from
+iterative deepening can be more than made up from better move ordering."* So ID is
+the standard *engine* of move ordering, and by §6.3.1 move ordering is the whole
+game. On a fixed-depth game ID loses its time-management justification and keeps
+its ordering justification entirely. adr-004 lists "iterative deepening and move
+ordering" side by side; after this reading they should be listed as *one*
+mechanism, not two.
+
+**Horizon effects are dissolved only where the search is complete.** True for the
+3×3/4×4 exact solves. But adr-004 part 2 is explicitly a *depth-limited* alpha-beta
+agent on the full 5×5 — there the search never reaches ply 25, so horizon effects
+bite at full strength. Your paragraph reads as though the fixed depth protects the
+whole project; it protects exactly the part that was never at risk.
+
+**Quiescence is the one that should worry you.** The standard fix is to extend
+search until the position is "quiet". FLIPHEX has no quiet positions: *every*
+placement fires arrows, so the cell count can swing on every single ply, right up
+to ply 25. There is no fixed point for a quiescence extension to terminate at.
+That is the Othello profile again (Allis's fixed-termination class), and it says
+the depth-limited 5×5 agent's cut-off evaluation is *structurally* unreliable, not
+merely untuned. Worth raising against adr-004 part 2 as an open design item — and
+it is a further argument for the endgame databases, which are the only way to make
+the last plies exact instead of guessed.
+
+---
+
+## §6.2 — Optimal decisions in games (minimax)
+
+### 6.2.1 — The minimax value and algorithm
+**Prompt.** State the `MINIMAX(s)` recurrence exactly (the max/min alternation
+over UTILITY at terminals). This *is* the game-theoretic value — connect it to
+the Allis note's "who wins with perfect play" (H1). For FLIPHEX 3×3/4×4, minimax
+to the fixed depth 25/16 *is* the exact solve — is that a **weak** or **strong**
+solution in Allis's terms, and does running it from every position (not just the
+root) change the answer?
+
+**My take.**
+
+I understand the minimax algorithm as a recursive definition of the game-theoretic value of every reachable state. Russell and Norvig define `MINIMAX(s)` as follows:
+
+- If `IS-TERMINAL(s)`, then `MINIMAX(s) = UTILITY(s)`.
+- If `TO-MOVE(s) = MAX`, then `MINIMAX(s) = max_{a ∈ ACTIONS(s)} MINIMAX(RESULT(s, a))`.
+- If `TO-MOVE(s) = MIN`, then `MINIMAX(s) = min_{a ∈ ACTIONS(s)} MINIMAX(RESULT(s, a))`.
+
+The alternating maximization and minimization reflects the assumption that both players act rationally and play optimally. Consequently, the value computed at the initial state is not merely an evaluation of the current position but the game-theoretic value of that position under perfect play.
+
+This interpretation is consistent with Allis's notion of determining "who wins with perfect play." In Russell and Norvig, minimax is the algorithm that computes this value; in Allis, the same value serves as the criterion for classifying whether a game has been solved. Thus, minimax provides the computational mechanism, while Allis provides the terminology for interpreting the result.
+
+For FLIPHEX, assuming exhaustive minimax can be performed over the complete game tree (16 plies on a 4×4 board or 25 plies on a 5×5 board), the value obtained at the initial state constitutes an exact solution of the game from its starting position. According to Allis's taxonomy, this corresponds to a **weak solution**, because it establishes the game-theoretic value and an optimal strategy from the initial position only.
+
+If minimax is computed for every reachable position, rather than only the initial state, the result becomes a **strong solution**. In that case, the solver knows the game-theoretic value and an optimal move for every reachable state, allowing perfect play regardless of how the current position was reached, including positions arising from earlier mistakes by either player.
+
+This distinction is important for H1. The hypothesis concerns determining the game-theoretic value of the initial FLIPHEX position—whether the first or second player has a forced win under perfect play—which is sufficient for a weak solution. Extending the computation to all reachable states would strengthen the result by constructing a complete oracle for the game, which is more closely aligned with the role envisioned for the solver in H3.
+
+**Refined write-up.**
+
+The recurrence is stated correctly, and the weak/strong distinction plus its
+mapping onto H1/H3 is the most valuable thing in this note. Two sharpenings, the
+second of which is a real trap.
+
+**Allis's strong solution quantifies over *legal* positions, not reachable ones.**
+He defines it as a strategy achieving the game-theoretic value "for all legal
+positions". The distinction is not pedantic here: FLIPHEX positions reachable only
+through a blunder are still legal, and those are exactly the positions H3 needs
+the oracle to answer, since the learned agent will visit them.
+
+**Alpha-beta does not hand you a strong solution as a by-product — this is the
+trap.** Your paragraph moves from "compute minimax for every reachable position"
+to "strong solution" as if it were a matter of running the same search more
+widely. Plain minimax does compute a value at every node it visits. **Alpha-beta
+does not.** Look at R&N's own pseudocode (Fig. 6.7): after `if v ≥ β then return
+v`, the returned `v` is a *bound*, not the node's value — the loop was abandoned.
+So the TT left behind by an alpha-beta solve is a mixture of exact values and
+one-sided bounds, and querying it as an oracle would silently return wrong
+answers. Real engines handle this by storing an EXACT/LOWER/UPPER flag with each
+entry; a solver that intends to be an oracle must either store only EXACT entries
+or re-search each query with a fresh (−∞, +∞) window.
+
+The good news is that the route you are already committed to sidesteps this
+entirely. **Retrograde analysis (§6.3.4) produces a strong solution natively** —
+R&N describe its output as *"a policy, which is a mapping from every possible
+state to the best move"*, which is Allis's strong solution in R&N's words. So the
+right plan for 4×4 is not "alpha-beta harder"; it is retrograde enumeration, which
+gives you (a) more than H1 needs — H1 only wants the root value, i.e. a weak
+solution — and (b) exactly what H3 needs, an oracle answerable at arbitrary
+positions. Bank that: the deliverable on 4×4 should be advertised as a **strong**
+solution, which is a stronger claim than checkers ever achieved on its full board
+(see §6.7.2).
+
+### 6.2.2 — Complexity, and why raw minimax is hopeless on 5×5
+**Prompt.** R&N give minimax as O(bᵈ) time. Plug in FLIPHEX's numbers
+(b starts 1450, d = 25 — see adr-004). Why is unpruned minimax a non-starter on
+5×5, and how does this motivate *both* pruning (§6.3, the classical route) *and*
+the learned value function (Axis 2)? This is the fork in the road between the two
+axes — state it in your own words.
+
+**My take.**
+
+Russell and Norvig show that the computational complexity of exhaustive minimax search is exponential in the depth of the game tree, requiring \(O(b^d)\) time, where \(b\) is the branching factor and \(d\) is the search depth. This complexity arises because every legal continuation must be explored under the assumption of perfect play.
+
+For FLIPHEX, this complexity becomes prohibitive. The game has a fixed depth of 25 plies, but the initial branching factor is approximately 1,450 legal actions. Even though the branching factor decreases as the board fills, the search space remains astronomically large, making an unpruned exhaustive minimax search computationally infeasible on the 5×5 board.
+
+I view this observation as the point where the project naturally splits into two complementary research directions.
+
+The first direction seeks to preserve exactness while reducing the number of states that must be explored. Classical search techniques—including alpha-beta pruning, effective move ordering, and transposition tables—do not alter the game-theoretic value being computed. Instead, they exploit structural properties of the search tree to avoid evaluating positions whose values cannot influence the optimal decision. The objective is therefore to compute the exact minimax value more efficiently.
+
+The second direction accepts that exhaustive search may remain impractical despite these optimizations. Instead of evaluating complete subtrees, it replaces exact recursive computation with a learned approximation of the value function. A neural network estimates the long-term utility of non-terminal positions, allowing search to terminate early while still producing strong decisions. This exchanges mathematical guarantees of optimality for computational tractability and empirical performance.
+
+I therefore see the exponential complexity of minimax not merely as a limitation but as the motivation for the project's two research axes. Axis 1 investigates how far exact search can be pushed through algorithmic improvements without sacrificing correctness. Axis 2 investigates whether learned value estimation can provide sufficiently accurate guidance when exact search becomes computationally infeasible. Both approaches address the same combinatorial explosion, but they do so by fundamentally different means: one reduces the search required to compute the exact value, whereas the other approximates the value itself.
+
+**Refined write-up.**
+
+"Reduce the search needed to get the exact value" versus "approximate the value
+itself" is a clean and correct statement of the fork. Two additions: the numbers
+you left out, and a third road the chapter names that your dichotomy misses.
+
+**Put the numbers in.** The crude figure is `1450²⁵ ≈ 10⁷⁹`. That over-counts,
+because `b` collapses as cells fill and hands empty; carrying the collapse through
+gives a 5×5 game tree of roughly **10⁶¹**. Either way the conclusion is the same,
+but the honest number is worth stating — and it sets up the key comparison in
+§6.3.1: the 5×5 *state space* is only 4.9 × 10¹⁷. A tree of 10⁶¹ over a state
+space of 10¹⁷·⁷ means the tree is ~10⁴³× redundant. That gap is not a curiosity;
+it is where the entire solver strategy lives.
+
+**There is a third road: replace search with lookup.** Your fork is
+exact-search-cheaper (§6.3) versus learned-approximation (Axis 2). R&N's §6.3.4
+adds a route that is neither — *retrograde enumeration*, which is exact and is not
+a tree search at all: it enumerates states, not paths, so the 10⁴³ redundancy
+above simply never gets paid. adr-004 in fact uses all three (reduced-variant exact
+solve, depth-limited alpha-beta on 5×5, retrograde endgame DBs), so the ADR is
+already ahead of this dichotomy — but the note should say *trifurcation*, because
+the third road is the one that actually delivers the 4×4 verdict (see §6.3.1).
+
+---
+
+## §6.3 — Heuristic alpha–beta tree search (the adr-004 core)
+
+### 6.3.1 — Why pruning is sound, and the move-ordering payoff
+**Prompt.** Explain *why* alpha-beta returns the exact minimax value despite
+pruning (the α/β bounds and the cutoff condition). Then the load-bearing fact for
+adr-004: with **optimal move ordering**, complexity drops from O(bᵈ) to
+**O(b^{d/2})** — derive/justify the exponent halving. adr-004 stakes the whole
+solver budget on ordering quality; does R&N's account support that emphasis?
+
+**My take.**
+
+Alpha-beta pruning is an optimization of minimax that preserves the exact game-theoretic value while reducing the number of states that must be evaluated. Its correctness follows from the observation that some branches can be proven incapable of influencing the final minimax decision.
+
+During search, alpha-beta maintains two bounds. The value α represents the best score that the maximizing player (MAX) can already guarantee along the current search path, while β represents the best score that the minimizing player (MIN) can already guarantee. As search progresses, these bounds become increasingly restrictive.
+
+A cutoff occurs whenever α ≥ β. At that point, the remaining unexplored successors of the current node cannot possibly change the value propagated to the parent. Regardless of their exact values, the parent node already has an alternative that is at least as good (for MAX) or at least as bad (for MIN). Consequently, omitting those branches does not alter the final minimax value. Alpha-beta therefore prunes search effort rather than changing the optimization objective.
+
+The effectiveness of alpha-beta depends critically on the order in which moves are examined. If the strongest moves are explored first, the α and β bounds tighten earlier, allowing more branches to be eliminated before they are searched. Russell and Norvig show that, under optimal move ordering, the effective time complexity improves from O(b^d) to O(b^{d/2}).
+
+The exponent is halved because effective pruning approximately doubles the search depth that can be reached for the same computational effort. Intuitively, instead of exploring nearly every branch at every level, alpha-beta rapidly establishes bounds that prevent large subtrees from being expanded. The search behaves approximately as though only every second level contributes the full branching factor, yielding an effective complexity proportional to the square root of the original search tree size.
+
+For FLIPHEX, this result strongly supports the design adopted in ADR-004. Given the extremely large branching factor, the quality of move ordering is not a secondary optimization but a primary determinant of solver performance. Better ordering does not improve the theoretical minimax value—it is already exact—but it substantially increases the amount of the search tree that can be discarded without affecting correctness. Consequently, investment in move ordering directly translates into a larger feasible search horizon under a fixed computational budget.
+
+**Refined write-up.**
+
+The soundness argument is correct and well stated: α and β are *achievable*
+guarantees already banked elsewhere in the tree, so a node whose value cannot
+escape the (α, β) window cannot change what the parent propagates. Keep that.
+The exponent argument needs the actual derivation, and then the FLIPHEX numbers
+overturn your closing sentence.
+
+**The halving, properly (Knuth–Moore minimal tree).** Your "the search behaves
+approximately as though only every second level contributes the full branching
+factor" is the right picture but stops before the mechanism. With perfect
+ordering, at any node the best move is tried first. That first child must be
+searched in full, because its value *becomes* the node's value. Every sibling
+only has to be **refuted** — shown to be no better — and refuting a MIN node
+requires exhibiting just *one* of its children that already falls outside the
+window. So the levels alternate: `b` children, then 1, then `b`, then 1, …
+Counting leaves gives
+
+```
+b^⌈d/2⌉ + b^⌊d/2⌋ − 1   ≈   O(b^{d/2})
+```
+
+Equivalently the effective branching factor is √b. R&N give the calibration
+directly — *"for chess, about 6 instead of 35… alpha-beta with perfect move
+ordering can solve a tree roughly twice as deep as minimax in the same amount of
+time"* — plus the figure you omitted, which is the realistic one: with **random**
+ordering it is `O(b^{3d/4})`, and a simple domain ordering gets within about a
+factor of 2 of the best case. Perfect ordering is unattainable by definition (R&N:
+*"in that case the ordering function could be used to play a perfect game"*).
+
+**Now the numbers, and they do not support your conclusion.** Apply `b^{d/2}` to
+FLIPHEX:
+
+| | game tree | perfect-ordering αβ | state space |
+|---|--:|--:|--:|
+| 4×4, adr-009 deck (b₀ = 576, d = 16) | ~10³³ | **~10¹⁶·⁵** | **9.3 × 10¹⁰** |
+| 5×5, full deck (b₀ = 1450, d = 25) | ~10⁶¹ | ~10³⁰·⁵ | 4.9 × 10¹⁷ |
+
+Perfect move ordering — an unattainable upper limit — leaves the 4×4 exact solve
+at ~10¹⁶·⁵ nodes. That is **not** solvable. Yet the 4×4 is solvable, because its
+state space is only ~10¹¹. The five-and-a-half orders of magnitude between
+10¹⁶·⁵ and 10¹¹ are *transpositions*, and they are recovered by the
+transposition table, not by ordering. R&N flag the same effect for chess in the
+same section — *"use of transposition tables is very effective, allowing us to
+double the reachable search depth"* — i.e. a win of the same order as perfect
+ordering; in FLIPHEX, where the tree is ~10²² times its own state space at 4×4,
+it is far larger.
+
+**So adr-004's emphasis is misallocated, and this note should say so.** The ADR
+states that "move ordering quality drives everything" and puts the solver budget
+there. The corrected reading splits it in two:
+
+- For the **depth-limited 5×5 agent** (adr-004 part 2), ordering does drive
+  everything — that agent's whole value is the depth it reaches per second.
+- For the **4×4 exact solve** (adr-004 part 1, the one carrying H1/H2), ordering
+  is secondary. What makes it tractable is that the state space is small enough
+  to enumerate, so the binding constraint is **memory and state enumeration, not
+  pruning**. 9.3 × 10¹⁰ states at 2 bits each is ~23 GB — a storage-and-I/O
+  engineering problem, not a search-heuristic one.
+
+That is a genuine ADR-level finding rather than a note-level detail, and it is the
+one thing from this chapter that should go back into adr-004.
+
+### 6.3.2 — Transposition tables and cut-off (heuristic) evaluation
+**Prompt.** R&N introduce transposition tables and the `H-MINIMAX` cut-off with
+an evaluation function + `CUTOFF-TEST`. Two FLIPHEX connections: (a) adr-004's
+Zobrist TT keys only on `(cell,colour)` and `(player,tile)` — is that consistent
+with R&N's notion of a transposition, given FLIPHEX's inert tiles (adr-003)?
+(b) FLIPHEX has **no natural heuristic** (a student game, no expert eval) — how
+much of §6.3's strength depends on a good `EVAL`, and what does its absence imply
+for a *pure* alpha-beta agent on 5×5? (Ties to the Allis §5 Connect-Four lesson.)
+
+**My take.**
+
+Russell and Norvig present transposition tables as a mechanism for avoiding redundant search by storing the computed value of previously evaluated positions. Their effectiveness relies on the observation that the same game state may be reached through different sequences of moves. Once the minimax value of such a state has been computed, it can be reused whenever that state reappears, eliminating unnecessary recomputation without changing the exact result.
+
+This interpretation is consistent with the transposition table proposed in ADR-004. The Zobrist hash is defined only over the board configuration `(cell, colour)` and the remaining resources `(player, tile)`. According to ADR-003, FLIPHEX tiles become inert after placement: they never move, change state, or acquire additional properties. Therefore, the future evolution of the game is completely determined by the current board position, the remaining tiles available to each player, and the player to move. The path used to reach that position is irrelevant. Consequently, two histories producing identical values for these state variables represent the same game state and may safely share a transposition-table entry.
+
+Russell and Norvig then introduce heuristic minimax (H-MINIMAX), in which search is terminated before reaching terminal states according to a `CUTOFF-TEST`, and an evaluation function estimates the utility of the resulting frontier positions. Unlike transposition tables, this modification changes the nature of the computation: the algorithm no longer returns the exact game-theoretic value but an approximation whose quality depends directly on the evaluation function.
+
+This distinction is particularly important for FLIPHEX. Unlike chess or other well-studied games, FLIPHEX has no established body of expert knowledge from which a reliable heuristic evaluation function can be derived. As a student-designed game, it lacks decades of accumulated strategic understanding. Consequently, the effectiveness of H-MINIMAX cannot be assumed. A weak evaluation function may produce poor move ordering and inaccurate frontier estimates, substantially reducing playing strength.
+
+This observation reinforces the architectural separation between the project's two research axes. Transposition tables remain valuable because they improve computational efficiency without sacrificing correctness. In contrast, heuristic cutoff search depends on domain knowledge that FLIPHEX currently lacks. This limitation motivates investigating learned value functions in Axis 2, while simultaneously explaining why Axis 1 emphasizes exact search techniques such as alpha-beta pruning and transposition tables. The discussion is consistent with Allis's analysis of Connect Four, where successful search depended critically on domain-specific knowledge rather than brute-force minimax alone.
+
+**Refined write-up.**
+
+**(a) The transposition argument is correct, and it is worth having as a proof
+rather than an appeal to intuition.** The claim needing support is that
+`(board colouring, both hands)` is a *sufficient statistic* for the future. It is,
+in two steps: placed tiles are inert (adr-003), so no placed tile contributes
+anything to future dynamics beyond the colour it left behind; and flips never
+chain (adr-006), so `RESULT` depends only on the current colouring and the action.
+Hence any two histories agreeing on (colouring, hands) have identical futures.
+That is Markov, and it is what licenses sharing a TT entry.
+
+Two things fall out that the ADR should absorb:
+
+- **Side-to-move needs no Zobrist key.** Exactly one cell fills per ply, so the
+  mover is the parity of the filled-cell count — a function of the board, not
+  independent state. Worth stating, because omitting side-to-move from a hash key
+  is normally a bug, and here it is provably not one.
+- **adr-004's key count looks wrong.** It says Zobrist keys on `(cell, colour)`
+  *and* `(player, tile)` — "50 random words". But 50 = 25 cells × 2 colours; the
+  hand component needs a further 13 tiles × 2 players = 26. The count should be
+  **76**, or the sentence should say the 50 covers only the board. Small, but it
+  is the kind of slip that ships.
+
+One caveat you did not reach, and it connects to §6.2.1: R&N describe the TT as
+caching *"the heuristic value of states"*. Under alpha-beta many stored entries
+are **bounds**, not values. A TT built during an alpha-beta run is therefore not
+directly usable as the exact-solve output; entries need an EXACT/LOWER/UPPER flag,
+or the solve needs to be retrograde in the first place.
+
+**(b) On the missing heuristic — right, and R&N make it quantitative.** §6.7 turns
+"a weak `EVAL` hurts" into a number: with independent errors of standard deviation
+σ = 5, minimax picks the *worse* branch 71% of the time in their two-ply example
+(58% at σ = 2), and *"if errors in the evaluation function are not independent,
+then the chance of a mistake rises"* — which is the FLIPHEX case, since sibling
+positions differ by one placement and their evaluation errors would be strongly
+correlated. So a pure depth-limited alpha-beta agent on 5×5 with a naive `EVAL`
+is not merely "weaker than it could be"; its move choice is close to a coin flip
+in the positions that matter.
+
+Two pointers that strengthen the paragraph. First, R&N's own §6.3.3 evidence for
+this comes from **Othello** (Buro's PROBCUT on LOGISTELLO) — the game whose
+Allis-profile FLIPHEX shares. Second, the honest implication is not "avoid
+heuristics" but "the heuristic must be *learned*, not authored" — which is the
+cleanest single-sentence justification for Axis 2 in the whole chapter, and worth
+lifting into adr-005's context section.
+
+Finally, the Connect-Four attribution is right in substance (Allis's 1988 solution
+was knowledge-based, with brute-force solutions coming later) but it comes from
+the [Allis note](notes/allis-1994-searching-for-solutions.md), not from this
+chapter — R&N mention Connect Four only in the bibliography. Keep the citation
+pointing at Allis.
+
+### 6.3.3 — Forward pruning, ordering heuristics, and the endgame
+**Prompt.** Catalogue the practical accelerators R&N list (killer moves, history
+heuristic, null-move, late-move reductions, beam/forward pruning). Which are
+*safe* (value-preserving) versus *risky* (may miss the exact value)? For the
+adr-004 retrograde endgame DBs, R&N discuss precomputed endgame tables — capture
+how they frame table lookup as a perfect evaluator, and reconcile with adr-004's
+`k ≤ 5` slice.
+
+**My take.**
+
+Russell and Norvig describe several practical techniques for accelerating game-tree search beyond basic alpha-beta pruning. These techniques differ fundamentally in whether they preserve the exact minimax value or intentionally trade correctness for additional speed.
+
+Some accelerators are **value-preserving** because they affect only the order in which the search explores nodes. Examples include move ordering heuristics such as the killer-move heuristic, the history heuristic, and transposition-table move ordering. These methods attempt to examine promising moves earlier, increasing the effectiveness of alpha-beta pruning without changing the set of positions that are ultimately searched if no cutoffs occur. Consequently, they preserve the exact minimax value while improving computational efficiency.
+
+Other techniques are **heuristic reductions** that deliberately avoid exploring parts of the search tree. These include null-move pruning, late-move reductions, beam search, and other forms of forward pruning. Their effectiveness depends on assumptions about which branches are unlikely to affect the final decision. Because these assumptions are heuristic rather than logically guaranteed, they may prune a branch that actually contains the optimal continuation. As a result, these methods sacrifice the guarantee of computing the exact minimax value in exchange for significantly faster search.
+
+This distinction aligns naturally with the philosophy adopted in ADR-004. Since the objective of Axis 1 is to construct an exact solver, value-preserving optimizations are compatible with the architectural goals, whereas heuristic pruning techniques should be treated cautiously because they weaken the mathematical guarantees required for proving the game-theoretic value.
+
+Russell and Norvig also discuss precomputed endgame databases as an alternative to heuristic evaluation. Rather than estimating the value of late-game positions, these databases store the exact game-theoretic values of previously solved states. A table lookup therefore functions as a perfect evaluation function: once a searched position falls within the database, no further search or heuristic estimation is required because the exact minimax value is already known.
+
+This perspective is consistent with the retrograde endgame databases proposed in ADR-004. Restricting the database to positions with at most five remaining moves (k ≤ 5) represents a practical compromise between storage requirements and computational benefit. Within this slice, the database acts as an exact oracle rather than an approximation, replacing search with constant-time retrieval while preserving correctness. The limitation is not conceptual but practical: only a suffix of the complete state space is stored.
+
+**Refined write-up.**
+
+The safe/risky split is exactly R&N's own framing — alpha-beta prunes what *"can
+have no effect on the final evaluation"*, forward pruning prunes what *"appear to
+be poor moves, but might possibly be good ones… at the risk of making an error"*.
+And "the database is a perfect evaluator, so the limitation is practical, not
+conceptual" is the right reading of §6.3.4. Three corrections, and one number that
+should change adr-004.
+
+**The catalogue is partly imported.** What R&N actually name in this chapter:
+killer moves, transposition tables and iterative-deepening ordering (§6.2.4); beam
+search, PROBCUT and late move reduction (§6.3.3). **Null-move pruning is not in
+this chapter**, and the *history heuristic* is not named either — §6.2.4 only
+describes the general idea of "trying first the moves that were found to be best
+in the past" and labels those killer moves. Both techniques are real, but citing
+them to R&N §6 would be a miscitation.
+
+**One wording slip.** You wrote that ordering heuristics preserve value "without
+changing the set of positions that are ultimately searched if no cutoffs occur."
+Ordering *does* change which positions get searched — that is the entire point of
+it. What is preserved is the returned **value**, not the visited set. Say
+value-preserving, not search-preserving.
+
+**PROBCUT deserves promotion from the "risky" bin.** It is risky in the strict
+sense, but Buro's result is that LOGISTELLO with PROBCUT *"beat the regular
+version 64% of the time, even when the regular version was given twice as much
+time"* — on Othello. For the depth-limited 5×5 agent, where exactness is already
+abandoned, that is a strong candidate rather than a hazard. Keep it firmly out of
+the 3×3/4×4 exact solves.
+
+**And the number that matters: `k ≤ 5` may be too ambitious.** R&N calibrate the
+industrial ceiling — chess tables are complete *"for all endings with seven or
+fewer pieces. The tables contain 400 trillion positions"* (4 × 10¹⁴), with
+eight-piece at 4 × 10¹⁶ and undone. Applying the adr-003 bound to FLIPHEX's
+last-`k`-empty slice:
+
+| k | positions with exactly k empty | cumulative ≤ k |
+|--:|--:|--:|
+| 3 | 9.0 × 10¹² | 9.4 × 10¹² |
+| 4 | 1.4 × 10¹⁴ | 1.5 × 10¹⁴ |
+| 5 | 1.1 × 10¹⁵ | **1.2 × 10¹⁵** |
+
+So `k ≤ 5` is ~3× *larger* than the complete 7-piece chess tablebase — a
+multi-institution effort — while `k ≤ 3` (10¹³) is comfortable on a laptop and
+`k ≤ 4` (10¹⁴) is roughly at the chess ceiling. Two honest caveats before
+rewriting the ADR: these are **upper** bounds (the `2^t` factor treats every
+2-colouring as reachable, which it is not), so the true counts are lower by an
+unknown factor; and endgame states compress well. But adr-004 currently presents
+`k ≤ 5` as the target and `k ≤ 3` as a fallback, and the arithmetic says the
+default expectation should be inverted: **`k ≤ 3` is the commitment, `k ≤ 4`
+the stretch, `k = 5` only if the reachability gap turns out to be large.** Worth
+an ADR amendment, and worth measuring the real reachable count on 3×3 first,
+where it can be enumerated exactly and the bound's slack can be calibrated.
+
+---
+
+## §6.4 — Monte Carlo Tree Search (the bridge to Axis 2) 🔄
+
+### 6.4.1 — The four MCTS phases and UCB1/UCT
+**Prompt.** Write the four phases (selection, expansion, simulation/playout,
+back-propagation) and the **UCB1** selection formula
+`argmax( Q(a) + c·√(ln N / n(a)) )`. What problem does the exploration term
+solve, and why does MCTS beat alpha-beta precisely where alpha-beta struggles —
+high branching factor and **no reliable heuristic** (exactly FLIPHEX's situation
+on 5×5)?
+
+**My take.**
+
+Russell and Norvig describe Monte Carlo Tree Search (MCTS) as an incremental search algorithm that estimates the value of actions through repeated sampling rather than exhaustive exploration. Each iteration consists of four phases:
+
+1. **Selection:** Starting from the root, repeatedly select child nodes according to the UCT policy until reaching a node that is either terminal or not fully expanded.
+2. **Expansion:** If the selected node is non-terminal and has unexplored legal actions, create one or more new child nodes corresponding to those actions.
+3. **Simulation (playout):** From the newly expanded node, simulate a complete game—typically using a simple default policy—until reaching a terminal state.
+4. **Back-propagation:** Propagate the simulation outcome back through every node visited during the iteration, updating the accumulated statistics used by future selections.
+
+During the selection phase, MCTS applies the UCB1 rule to balance exploitation and exploration:
+
+\[
+\operatorname*{argmax}_{a}
+\left(
+Q(a)
++
+c\sqrt{\frac{\ln N}{n(a)}}
+\right),
+\]
+
+where \(Q(a)\) is the estimated value of action \(a\), \(N\) is the number of visits to the current node, \(n(a)\) is the number of times action \(a\) has been selected, and \(c\) controls the exploration–exploitation trade-off.
+
+The exploration term addresses a fundamental limitation of purely greedy search. If action selection were based only on the current value estimate \(Q(a)\), the algorithm could prematurely commit to moves that appear promising because of limited evidence while neglecting alternatives that have been explored only a few times. The exploration bonus assigns higher priority to rarely visited actions, ensuring that uncertainty is gradually reduced rather than ignored.
+
+I interpret MCTS as addressing a different computational bottleneck than alpha-beta. Alpha-beta remains an exact search algorithm whose efficiency depends on proving that large portions of the tree are irrelevant, making it most effective when good move ordering and reliable evaluation permit aggressive pruning. MCTS, by contrast, never attempts to evaluate the entire search tree. Instead, it concentrates computational effort on regions that appear statistically promising, allowing useful decisions to emerge from repeated sampling even when exhaustive search is impossible.
+
+This distinction is particularly relevant for FLIPHEX on the 5×5 board. The game combines a very large branching factor with the absence of an established heuristic evaluation function. These are precisely the conditions under which exhaustive alpha-beta becomes difficult to scale, whereas MCTS remains practical because it requires neither complete tree expansion nor expert-crafted evaluation heuristics. This observation provides the conceptual bridge from the exact-search focus of Axis 1 to the learning-based methods developed in Axis 2.
+
+**Refined write-up.**
+
+The four phases, UCB1, and the exploration rationale are all correct. What the
+take gestures at but does not name is R&N's actual *mechanism* for why MCTS wins
+in this regime, and there are two FLIPHEX-specific consequences worth banking.
+
+**The mechanism is error aggregation, not effort allocation.** You framed it as
+"MCTS concentrates effort where it is statistically promising." True, but R&N's
+argument is sharper: *"A miscalculation on a single node can lead alpha–beta to
+erroneously choose (or avoid) a path to that node. But Monte Carlo search relies
+on the aggregate of many playouts, and thus is not as vulnerable to a single
+error."* Alpha-beta propagates one leaf's error straight to the root by
+construction — the max/min chain has no averaging anywhere in it. MCTS averages.
+That is why the eval-error result quoted in §6.3.2 (σ = 5 → wrong branch 71% of
+the time) hits alpha-beta and not MCTS, and it is the *same* fact stated twice.
+
+**R&N also name two MCTS disadvantages, and FLIPHEX dodges one of them for free.**
+They are: (i) *"a single move can change the course of the game… a vital line of
+play might not be explored at all"*; and (ii) positions that are obviously won
+*"but where it will still take many moves in a playout to verify the winner."*
+Disadvantage (ii) is essentially void for FLIPHEX — a playout is at most 25 plies,
+always terminates, and always yields a decided winner (draws impossible). So the
+whole *early playout termination* apparatus R&N describe is unnecessary here, and
+playouts cost microseconds. Disadvantage (i) does apply and is the real risk, and
+it is precisely what the exact solver is there to catch.
+
+**Consequence worth flagging: plain UCT is a cheap, strong baseline for FLIPHEX
+that the project currently has no slot for.** Given free playouts and no need for
+an evaluation function, a no-network UCT agent can be built in an afternoon and
+gives a strength yardstick between "random" and "AlphaZero". Note the tension
+though: adr-004 rejects MCTS *as the Axis 1 method* on independence grounds, and
+that rejection stands. A plain-UCT **baseline** is a third thing — neither ground
+truth nor the learned agent — so if it is added, it must be labelled as a
+yardstick and kept out of any H3 cross-check, or the axis independence adr-004
+protects is quietly lost. Park it as an open idea rather than smuggling it into an
+axis.
+
+One constant to leave alone: R&N's `c = √2` is the theoretical UCB1 value for
+rewards in [0, 1]; treat it as a starting point to tune, not a number to copy.
+
+### 6.4.2 — From generic UCT to AlphaZero's PUCT 🔄
+**Prompt.** R&N's MCTS uses *random* (or lightly-guided) playouts and UCB1.
+AlphaZero (Silver 2018, your note) replaces playouts with a **learned value
+head** and UCB1 with **PUCT** (prior P(a) from the policy head, no rollouts).
+List the exact substitutions. This is the crux of **synthesis S4** — answer the
+comparison in [phase2-synthesis.md](notes/phase2-synthesis.md), and here only
+note the one-line mapping. Which of FLIPHEX's Axis-2 design choices (adr-005) are
+already visible, in embryo, in R&N's generic MCTS?
+
+**My take.**
+
+Russell and Norvig present the generic Monte Carlo Tree Search framework based on UCT, in which node selection is guided by UCB1 and leaf evaluation is obtained through simulation (playout) to terminal states. AlphaZero can be understood as a specialization of this generic framework rather than a fundamentally different search algorithm.
+
+At a high level, the mapping is:
+
+- **UCT selection (UCB1)** → **PUCT selection** using policy-network priors.
+- **Random or lightly guided playouts** → **Learned value network** for leaf evaluation.
+- **Simulation-derived action preferences** → **Policy-network priors** that guide search from the outset.
+- **Search statistics alone** → **Search statistics combined with neural-network predictions**.
+
+This chapter therefore provides the conceptual foundation for the design adopted in ADR-005. The essential MCTS structure—selection, expansion, and back-propagation—remains unchanged, while AlphaZero modifies only how nodes are selected and evaluated. The detailed comparison between UCT and PUCT belongs in the synthesis note (S4).
+
+**Refined write-up.**
+
+Right to keep this short and push the comparison to S4. Three fixes to the mapping
+before it gets carried into the synthesis.
+
+**The playout is deleted, not replaced.** Your third row ("simulation-derived
+action preferences → policy priors") blurs two distinct changes. AlphaZero removes
+the simulation phase outright: the leaf is scored by one network call returning
+`(p, v)`, so MCTS drops from four phases to three. That is not a swap of playout
+policy — it is the removal of the only unbiased estimator in the algorithm, traded
+for a learned one. Worth stating plainly, because it is also where AZ's failure
+mode comes from.
+
+**PUCT's exploration term is not a confidence bound.** UCB1's `c·√(ln N / n(a))`
+is derived from a concentration inequality — it is a bound on how wrong `Q(a)`
+could be. AlphaZero's `c·P(a)·√ΣN / (1 + N(a))` is not: it decays like `1/n`
+rather than `√(ln n / n)`, and it is *scaled by the prior*, so a move the policy
+head dislikes is explored less no matter how uncertain its value is. The
+substitution therefore trades a regret guarantee for prior-guided focus. Given
+FLIPHEX's b₀ = 1450, that trade is the whole reason AZ-style search is viable
+here — but it is a trade, and S4 should say so rather than presenting PUCT as
+"UCB1 with priors."
+
+**The substitution you missed is the important one.** All four of your rows are
+about how search *runs*. AlphaZero's defining move is what it does with the
+search *output*: the visit counts become the **policy training target**
+(`π ∝ N^{1/τ}`), so search improves the network which improves search. Without
+that row, AZ is just guided MCTS; with it, it is a closed learning loop. That is
+the row S4 should be built around.
+
+For adr-005: what is already in embryo in R&N's generic MCTS is the tree policy,
+the backup rule, and the visit-count-as-strength idea. What is *not* — and so must
+be justified independently in the ADR rather than inherited — is the learned
+evaluator, the prior-scaled exploration, and the training loop.
+
+---
+
+## §6.5 / §6.6 — Stochastic & partially observable games (OUT of scope — skim)
+
+### 6.5.1 — Confirm the scope boundary
+**Prompt.** One sentence each: R&N's expectiminimax (stochastic) and the
+belief-state treatment (partially observable). Confirm *why* both are irrelevant
+to FLIPHEX per adr-001 (deterministic, perfect information). If either suggests a
+FLIPHEX *variant* worth parking (e.g. a hidden-hand variant), drop it in
+`notes/open-ideas.md`, not here.
+
+**My take.**
+
+Russell and Norvig extend adversarial search to stochastic games through **expectiminimax**, which introduces chance nodes representing probabilistic events and computes expected utilities rather than deterministic minimax values.
+
+For partially observable games, the chapter models decision making over **belief states**, where the agent maintains a probability distribution over possible underlying game states because the true state is not fully observable.
+
+Neither extension is relevant to FLIPHEX. According to ADR-001, FLIPHEX is a deterministic, two-player, zero-sum game with perfect information: every action has a deterministic successor, and both players always observe the complete game state. Consequently, neither chance nodes nor belief-state reasoning are required for the search algorithms considered in this project.
+
+**Refined write-up.**
+
+Correct and appropriately brief — the scope boundary holds exactly as adr-001
+draws it. One thing the skim surfaces that is worth parking rather than
+discarding: FLIPHEX has a completely natural §6.6 variant, namely **concealed
+hands**. The physical game is played with hands visible, but hiding them turns
+the state into a belief state over the opponent's remaining tiles, and — unusually
+— the belief is *exactly* computable, since the deck is a known 13-tile set and
+every placement removes one publicly. That makes it a rare partially-observable
+game with a tractable, finite, exactly-updatable belief state.
+
+It is firmly out of scope for this project (adr-001, and H6 is already the stretch
+slot). Log it in `notes/open-ideas.md` as a variant with a genuinely interesting
+formal property, and leave it there.
+
+---
+
+## §6.7 — Limitations of game search algorithms
+
+### 6.7.1 — Where alpha-beta and MCTS each break, and the honest headline
+**Prompt.** R&N close by naming the failure modes (alpha-beta's sensitivity to
+eval quality and horizon; MCTS's blind spots on traps/tactics requiring exact
+lines; both on huge branching). Map each to a FLIPHEX risk: which limitation
+threatens the *solver* (adr-004) and which the *learned agent* (adr-005)? This
+should sharpen the "solved on 3×3/4×4, endgame-exact on 5×5, strong elsewhere"
+honest-headline wording — does the chapter give you a reason to soften or harden
+any part of it?
+
+**My take.**
+
+Russell and Norvig conclude the chapter by emphasizing that no game-search algorithm is universally effective. The limitations depend not only on the search algorithm itself but also on the characteristics of the game and the available computational resources.
+
+For alpha-beta search, the principal limitations arise when complete search is impossible. In such cases, playing strength depends heavily on the quality of the evaluation function, and truncated search remains vulnerable to horizon effects. These limitations do not affect an exact search that reaches terminal states, but they become significant whenever heuristic cutoff evaluation is required.
+
+For Monte Carlo Tree Search, the principal limitation is different. MCTS allocates search effort statistically rather than proving exact values. Consequently, it may overlook tactically critical variations or narrow forced sequences that require exhaustive analysis but receive insufficient sampling. Although MCTS performs well in domains with very large branching factors and weak heuristic knowledge, it does not provide guarantees of optimal play.
+
+Applied to FLIPHEX, these limitations affect the project's two research axes differently. The primary risk for the exact solver (ADR-004) is not alpha-beta itself but the computational infeasibility of exhaustive search on the 5×5 game. As long as terminal states are reached or exact endgame databases are used, alpha-beta retains its correctness. Its practical limitation is computational scale rather than theoretical validity.
+
+For the learning-based agent (ADR-005), the principal risk is the absence of correctness guarantees. Even with a strong learned value function and MCTS, the resulting policy may still miss tactically decisive continuations or fail to recover the exact game-theoretic value in difficult positions. Consequently, empirical playing strength should not be interpreted as evidence that the game has been solved.
+
+Overall, this chapter reinforces rather than weakens the project's current research framing. It supports the distinction between proving the game-theoretic value (Axis 1) and approximating strong play (Axis 2), while emphasizing that these objectives require different algorithms because they optimize different criteria. I therefore see no reason to soften the project's headline. If anything, the chapter suggests making the distinction even more explicit: the 3×3 and 4×4 boards are targets for exact solution, the 5×5 endgame database provides exactness only within its stored region, and outside that region the learned agent should be presented as an approximation rather than a proof.
+
+**Refined write-up.**
+
+The conclusion is right and the three-tier headline you propose at the end is
+sharper than what adr-004 currently says. But the section is misattributed, and
+that is partly my fault — the prompt named "MCTS's blind spots on traps" as a §6.7
+item and it is not one.
+
+**What §6.7 actually lists** are four limitations, and only the first is
+algorithm-specific:
+
+1. **Alpha-beta's vulnerability to eval error** — with the σ argument (σ = 5 →
+   the "worse" branch is actually better 71% of the time), plus the note that
+   correlated errors make it worse. This is the one you got right.
+2. **Neither algorithm does metareasoning** — both compute values for all legal
+   moves even when the answer cannot change the decision. R&N: a better algorithm
+   would weigh the *utility of a node expansion* against its cost.
+3. **Both reason at the level of individual moves**, with no abstraction or
+   goal-directed planning (a human's "trap the queen").
+4. **Integrating machine learning** — R&N cite AlphaZero here as the early answer.
+
+MCTS's "a vital line of play might not be explored at all" is real and you stated
+it correctly, but it lives in **§6.4**, not §6.7. Cite it there.
+
+**Limitation 2 is unexpectedly on-topic for FLIPHEX and worth keeping.** R&N
+single out *"the case of symmetrical moves, for which no amount of search will
+show that one move is better than another."* FLIPHEX has exactly that structure:
+the Z/2 mirror ([adr-008](docs/adr/adr-008-board-mirror-symmetry.md)) makes
+mirror-image moves provably equal — but only once **both** `P3-y` tiles are placed,
+i.e. in the endgame. So the wasted-computation problem R&N describe is real here
+and is concentrated precisely in the retrograde databases, where folding it away
+is a clean ~2× win. That is the same conclusion adr-004's Phase 2 amendment
+reached, now with a textbook rationale behind it.
+
+**On the headline: harden it, don't soften it — but add the real risk.** Two
+adjustments. (i) On 3×3/4×4 the retrograde route yields a **strong** solution
+(§6.2.1), so "solved" understates it; say *strongly solved*. (ii) The threat to
+the exact half is not what you wrote. You say the risk is "computational
+infeasibility of exhaustive search" — but per §6.3.1 the 4×4 is not search-bound
+at all, it is **storage-bound** (~10¹¹ states, ~23 GB packed). Naming the risk
+correctly matters, because the mitigations are entirely different: better ordering
+buys nothing, disk-backed enumeration and state packing buy everything.
+
+So the honest headline becomes: *strongly solved on 3×3 and 4×4 (reduced deck,
+adr-009), exact in the last k plies on 5×5, strong-but-unproven elsewhere* — with
+the caveat that limitation 1 says the depth-limited 5×5 alpha-beta agent is the
+weakest component in the project, not the learned one.
+
+### 6.7.2 — The empirical claims (validation, adapted for a textbook)
+**Prompt.** The chapter cites landmark results (Deep Blue, checkers solved,
+AlphaGo/AlphaZero). Pick the two most relevant to FLIPHEX (checkers = exact
+solving via endgame DBs → Schaeffer, your *next* read; AlphaGo = learned play →
+Silver). Note how *rigorously* R&N state each (proof vs strong empirical
+evidence) — this calibrates how H1/H3 should phrase their own verdicts.
+
+**My take.**
+
+I see two landmark results as particularly relevant to the FLIPHEX project because they represent the two complementary research directions developed throughout this chapter.
+
+The first is the solution of checkers, which demonstrates that a sufficiently large game can be solved exactly through a combination of search, alpha-beta pruning, transposition tables, and extensive endgame databases. Russell and Norvig present this result as a mathematically established solution rather than merely a strong playing program. This example directly motivates the exact-solving objective of Axis 1 and provides the conceptual precedent for retrograde endgame databases, which I will study in greater detail through Schaeffer's work.
+
+The second is AlphaGo and its successor AlphaZero, which demonstrate that learned search can achieve superhuman playing strength in domains where exhaustive search is infeasible. Russell and Norvig present these systems as empirical achievements supported by competitive performance rather than as proofs of game-theoretic optimality. Their success therefore establishes the practical effectiveness of learned search without implying that the underlying games have been solved.
+
+This distinction is important for my own research framing. H1 should present conclusions about the game-theoretic value only when supported by exact search or mathematical proof. H3, by contrast, should evaluate the learned agent using empirical performance, agreement with the solver where available, and generalization to unseen positions, without implying that strong playing performance constitutes evidence of an exact solution.
+
+More generally, I appreciate that the chapter consistently distinguishes between proven correctness and demonstrated performance. That distinction should also guide the language used throughout this project, ensuring that exact solutions, empirical results, and learned approximations are never presented as equivalent forms of evidence.
+
+**Refined write-up.**
+
+The proof-versus-performance calibration is exactly the right thing to take from
+this section, and the H1/H3 split you draw from it is correct. One factual
+correction, and it strengthens your position rather than weakening it.
+
+**Checkers is weakly solved, not solved outright.** Schaeffer et al. (2007)
+proved the game-theoretic value of the *initial position* — a draw — using a
+10-piece endgame database plus a proof tree over the opening. They did not produce
+a value for every legal position, so it is a **weak** solution in Allis's sense.
+Your phrasing ("a mathematically established solution") is true but reads as
+stronger than what was achieved. Getting this right matters for two reasons:
+
+- **It is the right yardstick for H1.** H1 asks who wins from the initial
+  position. That is a weak solution — the same class of claim as checkers. So H1
+  is well-precedented and does not need to overreach.
+- **It sets up a claim you can legitimately make that checkers could not.**
+  Per §6.2.1, retrograde enumeration on 4×4 gives a value for *every* position —
+  a **strong** solution. On a smaller board, obviously; but the *class* of result
+  is stronger than the checkers headline, and that is worth stating precisely
+  rather than vaguely.
+
+Note also the asymmetry in how the two results are used in the chapter: checkers
+appears in §6.3.4 and the bibliography as a completed mathematical fact, whereas
+AlphaZero appears in §6.7 as an *open direction* ("we are just beginning to see
+programs like ALPHAZERO") and in §6.2.4 as an empirical performance claim
+("world-championlevel play"). R&N never assert that AlphaZero plays optimally.
+That is the register H3 should copy: agreement-with-the-oracle where the oracle
+exists, win-rate with confidence intervals where it does not, and no sentence
+that lets the two blur.
+
+Schaeffer 2007 is the right next read, and this section is the reason: it is the
+only published account of the exact pipeline the 4×4 solve now looks like —
+retrograde databases plus a proof over the remainder, and a storage problem rather
+than a search one.
+
+---
+
+## Lessons Learned
+
+This chapter reshaped how I think about adversarial search by separating the concepts of exact solving and strong play. I now see minimax as the recursive definition of the game-theoretic value of a state rather than simply a move-selection algorithm, with alpha-beta serving as an exact optimization that preserves this value through logical pruning.
+
+A key insight was that not all search accelerations are equivalent. Move ordering, transposition tables, and endgame databases reduce computation while preserving correctness, whereas heuristic evaluation, forward pruning, and related techniques deliberately trade mathematical guarantees for speed. This distinction strengthened the architectural separation between Axis 1 (exact search) and Axis 2 (learned approximation).
+
+The reading also clarified that a transposition table relies on a formally sufficient state representation rather than intuition. Correctness depends on demonstrating that all future evolution is determined solely by the encoded state variables, reinforcing the importance of the Markov assumption behind the ADR-004 state representation.
+
+Finally, the chapter reinforced the distinction between proof and empirical evidence. Exact search supports claims about the game-theoretic value of FLIPHEX, while learned agents support claims about playing strength. Keeping these forms of evidence separate will be essential throughout the project.
+
+## Failed Attempts
+
+At the beginning of the reading, I tended to think of minimax primarily as a search algorithm for choosing moves rather than as the mechanism that defines the game-theoretic value of every reachable state.
+
+I also implicitly associated exploring the complete game tree with obtaining a strong solution. Revisiting Allis's taxonomy clarified that the defining property of a strong solution is knowledge of the correct value and optimal move for every reachable position, not simply the amount of search performed.
+
+Another misconception was treating all search optimizations as equivalent. The reading clarified that some techniques preserve the exact minimax value by reducing redundant computation, while others replace exact computation with heuristic approximation. This distinction became central to how I now think about the architectural split between the project's exact solver and its learning-based agent.
+
+Finally, I initially accepted the FLIPHEX state representation as Markovian largely by intuition. The discussion around transposition tables highlighted that this is a formal assumption requiring justification from the game rules rather than an implementation convenience.

--- a/notes/russell-norvig-aima-ch6-adversarial-search.md
+++ b/notes/russell-norvig-aima-ch6-adversarial-search.md
@@ -695,17 +695,23 @@ Neither extension is relevant to FLIPHEX. According to ADR-001, FLIPHEX is a det
 **Refined write-up.**
 
 Correct and appropriately brief — the scope boundary holds exactly as adr-001
-draws it. One thing the skim surfaces that is worth parking rather than
-discarding: FLIPHEX has a completely natural §6.6 variant, namely **concealed
-hands**. The physical game is played with hands visible, but hiding them turns
-the state into a belief state over the opponent's remaining tiles, and — unusually
-— the belief is *exactly* computable, since the deck is a known 13-tile set and
-every placement removes one publicly. That makes it a rare partially-observable
-game with a tractable, finite, exactly-updatable belief state.
+draws it, and it holds more tightly than it first appears.
 
-It is firmly out of scope for this project (adr-001, and H6 is already the stretch
-slot). Log it in `notes/open-ideas.md` as a variant with a genuinely interesting
-formal property, and leave it there.
+It is worth recording *why* the obvious candidate variant fails, so nobody
+proposes it again later. Concealing each player's hand looks like it would turn
+FLIPHEX into a §6.6 belief-state game. It does not. The deck is a fixed, known
+13-tile set and every placement is public, so the opponent's remaining hand is
+always recoverable by subtraction: `hand = deck − tiles they have played`. The
+belief state is a point mass at every ply, which means there is no belief to
+maintain and no information to be gained by probing. Hiding the hand changes the
+bookkeeping burden on a human player and changes nothing about the game tree —
+it stays a perfect-information game, and `ACTIONS`/`RESULT` are untouched.
+
+Making the hidden information real would require the tiles a player holds to be
+*drawn*, not dealt in full — e.g. a random `k`-tile hand refilled from a shared
+pool. That introduces chance nodes, so it is excluded by adr-001 on the
+stochastic side as well as the observability side. Both of R&N's extensions stay
+out of scope, and there is no near-miss variant worth parking.
 
 ---
 

--- a/notes/schaeffer-2007-checkers-is-solved.md
+++ b/notes/schaeffer-2007-checkers-is-solved.md
@@ -337,7 +337,7 @@ corresponding endgame region occupies one of the widest parts") should come out.
 **Now the factual error, which runs the other way.** You wrote that the FLIPHEX
 figures "remain below the size of the ten-piece endgame databases reported for
 checkers." Check the exponents. The paper: *"a database of 3.9 × 10¹³ positions"*
-— so k≤3 (9.0 × 10¹²) is about **a quarter** of checkers', k≤4 (1.5 × 10¹⁴) is
+— so k≤3 (9.4 × 10¹²) is about **a quarter** of checkers', k≤4 (1.5 × 10¹⁴) is
 **~4× larger**, and k≤5 (1.2 × 10¹⁵) is **~30× larger**. Only k≤3 is comfortably
 below. That inverts your "not unprecedented" conclusion for the `k ≤ 5` target
 that adr-004 currently commits to.
@@ -409,7 +409,7 @@ Re-run the FLIPHEX numbers at that ratio, alongside the 2-bit figure you used:
 | target | positions | @ 2 bits | @ 154 pos/byte |
 |---|--:|--:|--:|
 | 4×4 full solve | 9.3 × 10¹⁰ | 23 GB | **0.6 GB** |
-| 5×5 endgame k≤3 | 9.0 × 10¹² | 2.3 TB | **61 GB** |
+| 5×5 endgame k≤3 | 9.4 × 10¹² | 2.4 TB | **61 GB** |
 | 5×5 endgame k≤4 | 1.5 × 10¹⁴ | 37 TB | **~1 TB** |
 | 5×5 endgame k≤5 | 1.2 × 10¹⁵ | 300 TB | **~7.8 TB** |
 

--- a/notes/schaeffer-2007-checkers-is-solved.md
+++ b/notes/schaeffer-2007-checkers-is-solved.md
@@ -86,11 +86,53 @@ expect the strongest published game-solving result to be a strong solution?
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The paper explicitly states that checkers has been **weakly solved**. According to Allis's taxonomy, this means that the game-theoretic value of the **initial position** has been established together with a strategy that achieves that value from the start of the game.
+
+The opening section states:
+
+> "This paper announces that checkers has been weakly solved."
+
+The authors further explain that the computational proof consists of an explicit strategy that never loses from the standard starting position, thereby proving that perfect play by both sides leads to a draw.
+
+This classification is important. Although the solution relies heavily on large retrograde endgame databases, those databases do not by themselves provide optimal play from every legal position. A strong solution would require the game-theoretic value and an optimal strategy for **every reachable position**, whereas the result presented here proves the value of the initial position through a combination of forward search and backward analysis.
+
+For the FLIPHEX project, Hypothesis H1 asks only for the game-theoretic value of the initial position. Therefore, H1 requires only a **weak solution**. The planned retrograde-analysis pipeline may compute substantially more information than is strictly necessary for H1, particularly within the enumerated portion of the state space, but that additional coverage should not automatically be interpreted as a strong solution. Whether the final solver satisfies the stronger criterion depends on whether it can correctly determine optimal play from every reachable position, not merely from terminal or near-terminal configurations.
+
+Before reading the remainder of the paper, one might expect the strongest published game-solving result to be a strong solution. Instead, the paper demonstrates that even an engineering effort spanning many years, combining large endgame databases with extensive forward search, was presented as a weak solution because the formal claim concerns the initial position rather than the entire reachable state space.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+Quote, classification and the H1 mapping are all correct — and finding the
+explicit sentence rather than inferring it was the right instinct, because the
+paper's headline ("checkers is now solved") is looser than its actual claim.
+
+One thing to add and one hedge to remove.
+
+**The paper uses "strongly solved" too — for the database region.** Component 1
+is described as *"a database of 3.9 × 10¹³ positions (all positions with ≤ 10
+pieces on the board) for which the game-theoretic value has been computed
+(**strongly solved**)"*. So checkers is weakly solved *overall* and strongly
+solved *within the ≤10-piece region*. That two-tier structure is exactly what
+FLIPHEX will produce on 5×5 — strongly solved for k ≤ 3, unproven above it — so
+it is worth borrowing the paper's own phrasing when the results are written up.
+
+**The hedge in your last-but-one paragraph is too cautious for 4×4.** You write
+that the extra coverage "should not automatically be interpreted as a strong
+solution," and that whether it qualifies "depends on whether it can correctly
+determine optimal play from every reachable position, not merely from terminal
+or near-terminal configurations." That caveat is right for **5×5**, where only a
+`k`-slice is enumerated. It does not apply to **4×4**: the plan there is to
+enumerate the *entire* state space (~9.3 × 10¹⁰ states), so every legal position
+gets a value by construction. Completeness is not something to be checked
+afterwards — it is what the algorithm does. So the 4×4 deliverable is a strong
+solution, and that is a *stronger class of claim than the checkers headline*,
+albeit on a much smaller game. Say it plainly; it is one of the few places the
+project can legitimately outrank a Science paper on a formal axis.
+
+Your prediction was the productive kind of wrong. The reason the strongest result
+is only weak is not modesty — it is economy: §6.1's "least amount of work"
+principle means you stop the moment the root value is proven. Strength beyond
+that is a by-product, not a goal.
 
 ### 1.2 — The complexity comparison, and a number that should unsettle you
 **Prompt.** The paper gives checkers ~5 × 10²⁰ positions and calls it "roughly one
@@ -105,11 +147,56 @@ almost certainly not be solved."
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The comparison is initially counterintuitive. The paper estimates the state-space complexity of checkers at approximately \(5 \times 10^{20}\) legal positions, whereas the current upper bound for reachable FLIPHEX 5×5 positions is approximately \(4.9 \times 10^{17}\). By state-space size alone, checkers is roughly three orders of magnitude larger.
+
+Nevertheless, the paper does not suggest that state-space size alone determines whether a game can be solved. Even before the technical sections, several limiting factors are already apparent.
+
+First, the solution required an exceptionally long engineering effort spanning approximately eighteen years, indicating that practical solvability depends on algorithmic advances, software engineering, and available computational resources rather than on state-space size alone.
+
+Second, the proof combines multiple complementary techniques rather than relying on exhaustive search. Large retrograde endgame databases, forward proof search, and substantial computational infrastructure all contribute essential components of the final result.
+
+Third, the paper emphasizes correctness as much as computation. Producing a result is insufficient; the computation must be organized so that the final claim constitutes a verifiable proof.
+
+At this stage, there is no evidence that the complexity of solving a game is determined solely by the number of reachable positions. The paper instead suggests that the structure of the state space and the ability to decompose the problem into tractable subproblems are likely to be equally important.
+
+For FLIPHEX, this observation weakens any argument based purely on state-space comparison. Although the estimated reachable state space is substantially smaller than that of checkers, this alone does not imply that a complete solution is practical. The decisive factors may instead lie in properties of the game graph and in the effectiveness of backward analysis and proof construction, topics developed in the following sections.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+You correctly refused the trap ("smaller state space ⇒ easier") and correctly
+identified that the paper never claims state count decides solvability. The three
+reasons you list are real but they are all *engineering* reasons — effort, tooling,
+verification. The structural reason is the one that actually settles it, and the
+paper hands you both halves of it.
+
+**The paper's own taxonomy places FLIPHEX awkwardly.** It says: *"Checkers is
+considered to have high decision complexity … and moderate space complexity
+(5 × 10²⁰). All the games solved thus far have either low decision complexity
+(Qubic; Go-Moku), low space complexity (Nine Men's Morris, size 10¹¹; Awari, size
+10¹²) or both (Connect Four, size 10¹⁴)."* Line FLIPHEX 5×5 up against that list:
+4.9 × 10¹⁷ is **three orders above Connect Four and five above Awari** — so
+FLIPHEX does not qualify as "low space complexity" by the standard of anything
+solved before checkers. This is a direct, citable **H4** datapoint and it is
+better than the vague "comparable to Reversi 6×6" wording H4 currently carries.
+
+**The binding constraint is game-tree complexity, not state count.** The paper
+gives the formula (*"A d-ply search with an average of b moves … results in a tree
+with roughly bᵈ positions"*) and its own effort figures: the stored proof tree is
+*10⁷ positions*, each costing ~10⁷ nodes of search, so *"10¹⁴ is a good ballpark
+estimate of the forward search effort"*. That is the number to compare against.
+Checkers' branching factor is tiny — the forced-capture rule keeps it near single
+digits — which is why a 10⁷-node proof tree can span the whole game. FLIPHEX
+starts at **b = 1450**. The 5×5 game tree is ~10⁶¹, and even at the unattainable
+`b^{d/2}` limit the forward proof is ~10³⁰·⁵
+([R&N note](notes/russell-norvig-aima-ch6-adversarial-search.md) §6.3.1).
+
+So: checkers has ~1000× more *states* than FLIPHEX 5×5 but roughly 10³⁰× fewer
+*tree nodes to prove*. State-space complexity and game-tree complexity are
+independent axes, and checkers is easy on the one that matters for a forward
+proof while FLIPHEX is catastrophic on it. That is the reason adr-004's "the full
+5×5 game will almost certainly not be solved" survives this paper — but note that
+the ADR currently justifies it by state count, which this reading shows is the
+*wrong justification for the right conclusion*. Worth amending.
 
 ---
 
@@ -129,38 +216,149 @@ simply vanishes for FLIPHEX, and does that make the FLIPHEX retrograde pass
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+Retrograde analysis proceeds by solving positions in reverse order of game progression. The computation begins with terminal positions, where the game-theoretic value is known by definition, and then propagates these values backward through the game graph.
+
+The paper describes constructing endgame databases incrementally. First, all one-piece positions are enumerated and solved. Their resolved values are then used to determine the values of two-piece positions. This process continues successively through three-piece positions and larger material configurations until all positions containing ten or fewer pieces have been solved.
+
+The backward propagation follows a rule that is the reverse of forward minimax evaluation. For each unresolved position, the values of all legally reachable successor positions are examined. A position is classified as a **win** if there exists at least one legal move leading to a position already known to be a loss for the opponent. Conversely, a position becomes a **loss** only after every legal successor has been established as a win for the opponent. This asymmetry is identical to the logical structure of minimax but applied in reverse: wins are discovered by the existence of a losing successor, whereas losses require exhaustion of all alternatives.
+
+Draws are more subtle. Unlike wins and losses, they cannot generally be inferred immediately because repeated positions may form cycles in the game graph without reaching a terminal state. Consequently, a position whose successors remain unresolved cannot automatically be classified as a draw. The paper therefore treats repetition explicitly during database construction, ensuring that cyclic play is correctly identified rather than being mistaken for an unresolved computation.
+
+For FLIPHEX, one major complication disappears. The game has neither repetition nor drawn outcomes: each move permanently occupies one previously empty cell, producing an acyclic game graph with a fixed maximum depth. As a result, every legal sequence eventually reaches a terminal position without revisiting an earlier state. The retrograde propagation therefore requires only the recursive determination of wins and losses, eliminating the need for special mechanisms to detect repetition-induced draws.
+
+This does not necessarily make retrograde analysis fundamentally different, since the underlying dynamic programming principle remains the same. However, it substantially simplifies the implementation. The absence of cycles means that every unresolved position must eventually be classified as either a win or a loss once all successors have been processed, avoiding one of the principal algorithmic complications addressed in the checkers databases.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+The win/loss asymmetry is stated exactly right — *win* is existential (one losing
+successor suffices), *loss* is universal (all successors must be wins) — and that
+asymmetry is the engine of the whole backward pass. The FLIPHEX conclusion is
+right too, but you undersell it: this is not merely "substantially simpler
+implementation", it is a **change of algorithm class**.
+
+**Checkers needs a fixpoint iteration; FLIPHEX needs a single sweep.** Because
+checkers' game graph has cycles (non-capture king moves return to earlier
+positions), values cannot be assigned in one pass — the computation must iterate
+until nothing changes, and positions that never resolve are draws by repetition.
+FLIPHEX's graph is a **DAG stratified by ply**: every move fills exactly one cell,
+so `t` strictly increases and layer `t` depends only on layer `t+1`. You process
+`t = 25, 24, 23, …` once each, in order, and you are done. No iteration, no
+convergence test, no draw category. That also means the pass is trivially
+streamable — one layer in memory at a time — which is exactly what makes the
+storage argument in §2.3 tractable.
+
+**And you get a bigger free win than you credited: the GHI problem disappears.**
+§4 of the paper describes *graph-history interaction* — the same position reached
+by two move sequences can have different values because draw-by-repetition depends
+on the path — and notes that *"part of this research project was to develop an
+improved algorithm for addressing the GHI problem."* GHI is a research
+contribution in its own right, and it exists only because of repetition draws.
+FLIPHEX has neither, so the position is genuinely path-independent, which is the
+same Markov property that licenses the transposition table
+([R&N note](notes/russell-norvig-aima-ch6-adversarial-search.md) §6.3.2). One
+assumption, three consequences.
+
+A caution worth carrying forward, though: no-draw is not a pure gift. It
+simplifies the *backward* pass, and it makes the *forward* proof harder — see the
+refinement to §6.1, where the absence of an intermediate value removes the
+partial-proof shortcut Schaeffer leans on.
 
 ### 2.2 — Convergence: why this worked for checkers and may not for FLIPHEX
 **Prompt.** *This is the load-bearing prompt of the whole note.* The paper notes
 that "the checkers forced-capture rule quickly results in many pieces being
 removed from the board, giving rise to a position with ≤10 pieces – and a known
-value." Checkers is a **converging** game: the state gets *smaller* as play
-proceeds, so the endgame is a narrow funnel every line must pass through.
-FLIPHEX is **diverging** — a tile is added every ply, so the endgame is the
-*widest* part of the state space, not the narrowest. Allis says endgame databases
-are "generally unfeasible for diverging" games.
+value." Checkers is a **converging** game: material only decreases, so the
+≤10-piece region is a funnel every long game is forced into.
 
-Answer three things. (a) Restate in your own words why convergence is what makes
-a 10-piece database *cover* the game rather than just decorate it. (b) For
-FLIPHEX, the last-`k`-empty slice grows explosively going backwards: k≤3 ≈
-9 × 10¹², k≤4 ≈ 1.5 × 10¹⁴, k≤5 ≈ 1.2 × 10¹⁵ (upper bounds). Compare with
-checkers' ≤10-piece database size, which the paper gives — is FLIPHEX's `k ≤ 5`
-target above or below what an 18-year multi-machine project achieved? (c) Given
-(a) and (b), is the answer to prompt 1.2 that FLIPHEX 5×5 *is* within reach, or
-that raw state count was never the binding constraint? State which, and why.
+FLIPHEX is **diverging** by Allis's formal criterion (Def. 6.1 — for the
+majority of edges in the piece-count class graph the successor class is larger:
+15 growing layers versus 10 shrinking ones). But be careful with what that label
+does and does not imply — Allis's own example is Othello, and he qualifies it:
+*"Except for the endgame, the number of legal positions increases."* FLIPHEX's
+layer profile is a **hump**, peaking at ply 15 (1.1 × 10¹⁷) and collapsing to
+3.4 × 10⁷ at ply 25. The endgame is the *narrowest* part, not the widest.
+
+So the interesting question is not "is the FLIPHEX endgame too big to enumerate"
+(it is not), but **what a database of the last `k` plies actually buys**. Answer
+four things. (a) Why does convergence make a 10-piece database *cover* the game
+rather than decorate it — and note the key structural fact: in checkers "≤10
+pieces" is decoupled from move number, so it can be entered early and cover a
+long tail of play. In FLIPHEX, `k` empty cells **is** ply 25−k, rigidly. (b) Get
+the checkers 10-piece database size from the paper and compare honestly against
+FLIPHEX's k≤3 ≈ 9 × 10¹², k≤4 ≈ 1.5 × 10¹⁴, k≤5 ≈ 1.2 × 10¹⁵ (upper bounds) —
+check the exponents carefully, the answer is not the one the shape of the
+question suggests. (c) Each ply further back costs roughly 5–10× more positions;
+what does that imply for how deep a FLIPHEX endgame database can usefully reach?
+(d) Given all of the above, is the answer to prompt 1.2 that FLIPHEX 5×5 *is*
+within reach, or that state count was never the binding constraint? Say which,
+and name the quantity that actually binds.
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The effectiveness of the checkers solution depends fundamentally on the game's **converging** state-space structure rather than on its absolute size. As pieces are captured during play, the number of legal positions decreases dramatically, so every sufficiently long game is forced into a comparatively small family of endgame positions. Consequently, solving all positions with ten or fewer pieces is not merely an optimization: it creates a common destination through which essentially every line of play must eventually pass. Once play reaches this region, exact game-theoretic values become available, allowing the forward proof to terminate by connecting to the solved database.
+
+FLIPHEX has the opposite structural property. Every move permanently adds one occupied cell, causing the state space to expand as the game progresses. Instead of converging toward a narrow endgame, legal play moves toward the largest layers of the game graph. Therefore, a retrograde database covering only the final few plies does not naturally intercept most games in the same way that a ten-piece database does in checkers. The database remains correct, but its strategic leverage is substantially reduced because there is no narrow funnel through which every game must pass.
+
+The numerical comparison reinforces this structural distinction. The estimated upper bounds for FLIPHEX are approximately \(9 \times 10^{12}\) positions for \(k \leq 3\) empty cells, \(1.5 \times 10^{14}\) for \(k \leq 4\), and \(1.2 \times 10^{15}\) for \(k \leq 5\). These values remain below the size of the ten-piece endgame databases reported for checkers. Purely in terms of database size, a FLIPHEX \(k \leq 5\) retrograde computation therefore appears to be within a range that is not unprecedented.
+
+However, this observation does not overturn the conclusion reached in Prompt 1.2. The limiting factor is not the raw number of stored states but the structural role played by those states within the game graph. In checkers, the solved endgame region covers the game because nearly every line is forced into it by progressive material reduction. In FLIPHEX, the corresponding endgame region occupies one of the widest parts of the state space, so solving it does not provide the same coverage of earlier play.
+
+Thus, the principal lesson is that state-space size alone is an insufficient predictor of solvability. The decisive property is whether backward-computed knowledge naturally propagates through the game graph to the initial position. Checkers possesses this converging structure; FLIPHEX does not. Consequently, the apparent similarity in database size should not be interpreted as evidence that the full 5×5 game is comparably easy to solve.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+**You were right to push back on the prompt, and the prompt was wrong.** The
+original wording claimed the FLIPHEX endgame is "the *widest* part of the state
+space". It is not — it is the narrowest. Your reasoning in chat (fewer tiles left,
+fewer empty cells, many paths funnelling into few terminal configurations) is
+correct, and the arithmetic confirms it:
+
+| ply `t` filled | `k` empty | positions | share |
+|--:|--:|--:|--:|
+| 8 | 17 | 9.8 × 10¹³ | 0.0% |
+| **15** | **10** | **1.09 × 10¹⁷** | **22.3%** ← peak |
+| 20 | 5 | 1.05 × 10¹⁵ | 0.2% |
+| 22 | 3 | 9.0 × 10¹² | 0.0% |
+| 25 | 0 | **3.4 × 10⁷** | 0.0% |
+
+The profile is a **hump**: it climbs for 15 plies and collapses for 10. There are
+only 33.6 million terminal positions in the whole game. The prompt conflated the
+*label* "diverging" with a claim about the endgame, and that inference does not
+follow. Allis himself flags it — his diverging example is Othello, and he writes
+*"**Except for the endgame**, the number of legal positions increases as the
+number of stones on the board increases."* The label is assigned by his Def. 6.1
+(majority of class-graph edges lead to a larger class: 15 growing versus 10
+shrinking), so FLIPHEX *is* formally diverging — but the label says nothing about
+the shape of the last few plies. Both halves of your take that repeat the prompt's
+premise ("legal play moves toward the largest layers of the game graph"; "the
+corresponding endgame region occupies one of the widest parts") should come out.
+
+**Now the factual error, which runs the other way.** You wrote that the FLIPHEX
+figures "remain below the size of the ten-piece endgame databases reported for
+checkers." Check the exponents. The paper: *"a database of 3.9 × 10¹³ positions"*
+— so k≤3 (9.0 × 10¹²) is about **a quarter** of checkers', k≤4 (1.5 × 10¹⁴) is
+**~4× larger**, and k≤5 (1.2 × 10¹⁵) is **~30× larger**. Only k≤3 is comfortably
+below. That inverts your "not unprecedented" conclusion for the `k ≤ 5` target
+that adr-004 currently commits to.
+
+**So what is the real structural difference?** Not width — *reach in game-time*.
+In checkers, "≤10 pieces" is a **material** condition, decoupled from move number:
+a game can enter that region at ply 20 and stay in it for another forty, so the
+database covers a long tail of actual play. In FLIPHEX, `k` empty cells **is** ply
+25−k, rigidly — one cell fills per ply, no exceptions. A `k ≤ 3` database covers
+exactly the last 3 plies of a 25-ply game, or 12%, and nothing you do changes
+that. Buying more reach costs ~5–10× positions per additional ply (k=3→4 is 15×,
+4→5 is 7.7×), so covering even half the game means enumerating essentially the
+whole state space. *That* is what Allis's "endgame databases are generally
+unfeasible for diverging games" actually means operationally, and it is a claim
+about coverage, not about layer size.
+
+Your conclusion therefore survives — state count was never the binding constraint
+— but the supporting argument needs replacing wholesale. And note what this does
+*not* say: the FLIPHEX endgame database is perfectly feasible and every game is
+guaranteed to pass through it. It just cannot be made deep enough to meet a
+forward proof coming down from a root with b = 1450. The two ends do not reach
+each other; that is the 5×5 obstacle, stated precisely.
 
 ### 2.3 — Storage, indexing and compression
 **Prompt.** Retrograde analysis is an I/O problem before it is a search problem.
@@ -173,11 +371,65 @@ depend on checkers-specific structure (piece counts, symmetry) FLIPHEX lacks?
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The paper makes it clear that large-scale retrograde analysis is primarily a data-management problem rather than a search problem. Once the recursive propagation rules are established, the dominant engineering challenges become storing, indexing, and efficiently accessing enormous collections of solved positions.
+
+The endgame databases are organized by material configuration, with separate databases constructed incrementally for positions containing increasing numbers of pieces. This partitioning allows each database to be generated using already-solved smaller databases while limiting the amount of information that must be accessed simultaneously.
+
+The Supporting Online Material explains that compact encodings and carefully designed indexing functions are essential. Rather than storing complete board descriptions, positions are mapped to compact indices so that each legal position corresponds to a unique database entry. Since each position ultimately requires only a small game-theoretic value (win, loss, or draw), aggressive bit packing substantially reduces storage requirements.
+
+The implementation also distinguishes between persistent data and transient computation. Solved position values are retained because they will be referenced repeatedly during later construction stages, whereas intermediate working structures used during database generation need not be preserved once a stage has completed. This tradeoff reduces permanent storage at the cost of recomputation where appropriate.
+
+Several of these engineering principles transfer directly to FLIPHEX. Compact value encoding (e.g., two bits per position), deterministic indexing from game states to array locations, sequential processing of database layers, and minimizing random I/O are independent of the game itself. These techniques remain applicable whenever the complete state space is explicitly enumerated.
+
+Other optimizations depend on structural properties specific to checkers. Database partitioning by remaining piece count follows naturally from material reduction during play. Efficient indexing exploits the representation of distinguishable piece types and legal material configurations. Symmetry reductions also benefit from the geometric and piece-specific properties of the game. FLIPHEX lacks this material-count hierarchy, since the number of occupied cells only increases, and its indexing scheme would instead be organized by the number of empty cells or move depth. Likewise, any symmetry reduction must be derived from the board geometry alone rather than from interchangeable piece configurations.
+
+For a complete 4×4 FLIPHEX solver, where approximately \(9.3 \times 10^{10}\) states require only about 23 GB at two bits per state, these implementation choices become first-order design decisions. The feasibility of the solver depends not only on the storage capacity but also on constructing an indexing scheme and access pattern that permit efficient retrograde propagation over tens of billions of positions.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+The transfers-versus-doesn't-transfer split is well drawn, and spotting that
+FLIPHEX's natural partition is *empty-cell count* rather than material is exactly
+right — that is the layer index the §2.1 single-sweep algorithm runs on. But you
+missed the paper's most consequential number, and it changes the project's
+arithmetic by two orders of magnitude.
+
+**39 trillion positions compressed into 237 gigabytes — "an average of 154
+positions per byte!"** That is ~**0.05 bits per position**, not the 2 bits you
+assumed. The paper is explicit about why it is achievable and what constraint it
+must respect: *"A custom compression algorithm was used which allows for rapid
+localized real-time decompression … the backward and forward search programs can
+quickly extract information from the databases with a relatively small
+overhead."* The hard requirement is **random access into compressed data**, not
+compression ratio in the abstract — a whole-file gzip would hit a similar ratio
+and be useless.
+
+Re-run the FLIPHEX numbers at that ratio, alongside the 2-bit figure you used:
+
+| target | positions | @ 2 bits | @ 154 pos/byte |
+|---|--:|--:|--:|
+| 4×4 full solve | 9.3 × 10¹⁰ | 23 GB | **0.6 GB** |
+| 5×5 endgame k≤3 | 9.0 × 10¹² | 2.3 TB | **61 GB** |
+| 5×5 endgame k≤4 | 1.5 × 10¹⁴ | 37 TB | **~1 TB** |
+| 5×5 endgame k≤5 | 1.2 × 10¹⁵ | 300 TB | **~7.8 TB** |
+
+This matters directly: I earlier advised (from raw counts) that `k ≤ 3` should be
+the commitment and `k ≤ 4` the stretch. At Schaeffer-class compression, k≤4 is a
+1 TB external drive and k≤5 is a NAS purchase rather than an impossibility. The
+storage argument was too pessimistic by ~40×. **Caveat, and it is a real one:**
+154 positions/byte reflects checkers endgame structure — long runs of identical
+win/loss/draw values under a material-based index. FLIPHEX's compressibility under
+an empty-cell index is *unmeasured*, and the honest move is to measure it on 3×3
+and 4×4 (where the whole space is enumerable) before committing a `k` in the ADR.
+That is a concrete, cheap Phase-3 experiment worth pre-registering.
+
+One correction to the transfer list: you write that checkers' "symmetry
+reductions also benefit from … piece-specific properties" and imply FLIPHEX must
+derive symmetry from geometry alone. True, but the useful consequence is more
+specific — per [adr-008](docs/adr/adr-008-board-mirror-symmetry.md) the Z/2 mirror
+becomes a *full* symmetry precisely once both chiral `P3-y` tiles are placed,
+which is a condition on the *endgame*. So mirror-canonicalising the index is
+available exactly where the databases live, for a clean ~2× on top of compression.
+Worth building into the indexing function from the start rather than retrofitting.
 
 ---
 
@@ -195,11 +447,53 @@ be rewritten around the meet-in-the-middle framing? Argue both sides.
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The proof procedure consists of three interacting components. First, retrograde analysis constructs exact endgame databases by propagating game-theoretic values backward from terminal positions. Second, a forward search starting from the initial position builds a proof tree using game-tree search. Third, an interface connects these two computations by terminating the forward search whenever a position already exists in the solved endgame databases.
+
+Conceptually, the computation proceeds from both directions simultaneously. The endgame databases grow upward from terminal positions toward increasingly complex game states, while the forward proof tree grows downward from the initial position. The proof is completed when every leaf of the forward search enters a region of the state space whose game-theoretic values have already been established by retrograde analysis.
+
+The logical claim at this junction is stronger than "the program plays well." Each leaf of the forward proof tree is not evaluated heuristically but replaced by an exact theorem supplied by the endgame database. Since the forward search is itself an exact minimax computation, every propagated value remains mathematically sound. The resulting argument forms a complete proof that the game-theoretic value assigned to the initial position is correct.
+
+This architecture differs fundamentally from a conventional game-playing engine. A strong playing program estimates values heuristically beyond its search horizon. Here, no heuristic evaluation is required once the search reaches the solved database. The horizon is replaced by exact knowledge, eliminating approximation from the proof.
+
+The architecture described in ADR-004 already contains the same two principal components: retrograde databases and alpha-beta search. However, they are currently presented as largely independent deliverables. The meet-in-the-middle interpretation offers a stronger conceptual organization by emphasizing that these components jointly establish a single proof rather than solving separate engineering problems.
+
+There are, however, reasonable arguments for retaining the current ADR structure. From a project-management perspective, separating the retrograde database from the forward solver produces clearer implementation milestones and independently testable artifacts. Conversely, if the ADR aims to justify the solver architecture rather than the development schedule, reorganizing it around the meet-in-the-middle proof would better reflect the paper's central contribution. The decision therefore depends on whether the ADR is intended primarily as an implementation roadmap or as an architectural rationale.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+The meet-in-the-middle picture is right, the "exact theorem replaces the horizon"
+formulation is the best sentence in the note, and framing the ADR question as
+*roadmap versus rationale* is a genuinely good way to hold both sides. Two fixes.
+
+**The third component is not an interface.** The paper's list is: *1. Endgame
+databases (backward search)*, *2. Proof-tree manager (forward search)*, *3. Proof
+solver (forward search)* — and of the solver it says *"this component uses two
+programs to determine the value of the position. These programs approach the task
+in different ways, thus increasing the chances of obtaining a useful result."*
+The junction between forward and backward is not a component; it is just a
+database lookup at the solver's leaves. Getting this right matters because
+component 3 is where the paper's redundancy lives — two independent programs
+attacking the same position — which is a design decision, not an implementation
+detail, and it feeds §5.1.
+
+**Your ADR argument is missing the fact that decides it.** You framed it as a
+presentational choice. It is not: adr-004's two halves currently target
+*different boards* — retrograde on the full 5×5 endgame, alpha-beta as a
+depth-limited 5×5 agent, and reduced-variant solves as a third, separate thing.
+They are not two ends of one proof; they never meet. Schaeffer's architecture is
+a single proof of a single position. So the honest reading is that adr-004 is
+**not** a meet-in-the-middle design today, and the question is whether it should
+become one. My reading of the numbers (§2.2, §1.2) is that on 5×5 it *cannot* —
+the endgame database cannot be pushed deep enough to meet a forward proof from
+b = 1450 — and on 4×4 it is *unnecessary*, because a full enumeration solves the
+whole board without needing a forward proof at all. Meet-in-the-middle is the
+right architecture for a game whose two ends can actually be joined; FLIPHEX 5×5
+is precisely the case where they cannot.
+
+That is worth writing into adr-004 explicitly, because "we considered the
+architecture that solved checkers and it does not apply here, for this reason" is
+a much stronger ADR than silence. Keep the current three-deliverable structure;
+add the rejected alternative.
 
 ---
 
@@ -233,11 +527,67 @@ it a single undifferentiated enumeration pass?
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The forward-search component is divided into two distinct responsibilities. The proof-tree manager determines which positions require proof and allocates computational effort across the evolving proof tree. Individual solvers are then responsible for proving the game-theoretic value of specific positions assigned by the manager. This separation allows global proof construction to remain independent of the algorithms used to solve individual subproblems.
+
+The paper emphasizes that the proof tree is substantially smaller than the complete search tree because not every branch must be explored to the same extent. At positions where the side to move seeks to establish a win, every opponent response must be addressed to ensure that no refutation exists. Conversely, for each opponent move, it is sufficient to identify a single continuation that preserves the desired game-theoretic value. Consequently, the proof records only the evidence required to establish the theorem rather than every possible continuation of play.
+
+This resembles the minimal-tree analysis of Knuth and Moore discussed by Russell and Norvig, but the two concepts are not identical. The minimal tree is a theoretical lower bound on the amount of search required by alpha-beta under perfect move ordering. It characterizes search complexity independently of any particular proof representation. The proof tree, by contrast, is the explicit mathematical object certifying the result. Although both exploit the asymmetry between existential ("there exists a winning move") and universal ("every opponent move must be answered") reasoning, the proof tree serves as a correctness certificate rather than merely a complexity bound.
+
+The architecture also relates naturally to Proof-Number Search (PNS). Like PNS, the proof-tree manager attempts to direct computational effort toward unresolved parts of the proof rather than expanding the game tree uniformly. However, the paper does not describe the manager as implementing PNS, nor does it rely on proof and disproof numbers as its central mechanism.
+
+For ADR-004, this paper provides additional motivation to reconsider the earlier decision to postpone proof-oriented search methods. The central role of explicit proof construction suggests that proof-directed search deserves architectural consideration. Nevertheless, the paper alone does not justify replacing alpha-beta with PNS. Instead, it supports viewing proof-oriented search as a potentially valuable extension whose benefits should be evaluated separately from the core meet-in-the-middle architecture.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+*(Note: this answers prompt **4.1**, not 4.2 — 4.1's slot above is still empty and
+4.2's actual question, about the manager's failure mode, is unanswered. Worth
+moving this text up; the missing 4.2 answer is sketched at the end here.)*
+
+The manager/solver split and the existential-vs-universal asymmetry are correct,
+and the Knuth–Moore distinction is the sharpest thing in the note: the minimal
+tree is a *complexity bound*, the proof tree is a *certificate*. Keep that
+wording. But the claim that decides the ADR question is wrong.
+
+**Proof-number search is not absent from this paper — it is the manager's core
+algorithm.** The text: *"The manager maintains the master copy of the proof, and
+identifies a prioritized list of positions that need to be examined **using the
+Proof Number search algorithm** (6)."* Reference (6) is Allis. The paper also
+names the **Df-pn** variant — *"builds the search tree in a depth-first manner,
+requiring less computer storage"*. So the largest game-solving result ever
+published uses PN-search as the scheduler that decides *what to prove next*, with
+alpha-beta (Chinook, 17–23 ply) as the solver underneath.
+
+This forces a correction to something **I** wrote, not just to your take. The
+adr-004 Phase 2 amendment argued that pn-search "loses its structural edge" on
+FLIPHEX because pn-search shines on *sudden-death* goal-proving and FLIPHEX is
+fixed-termination. Checkers is **also fixed-termination** (Allis classifies it
+so), and pn-search is central to its proof anyway. That argument was wrong as
+stated.
+
+What survives, and is the right distinction: adr-004 rejected pn-search *as a
+replacement search paradigm* — a second full engine to build, debug and explain.
+That rejection still stands. What adr-004 never considered is pn-search in
+Schaeffer's actual role: a **work scheduler over a proof tree**, sitting above
+ordinary alpha-beta solvers. Those are different decisions and the ADR conflates
+them. The amendment should be corrected to say so, and the honest verdict is your
+last sentence — reopened as a scoped extension, not adopted.
+
+Two more things the paper gives that belong in the ADR's thinking. First, the
+manager iterates not on depth but **on the error threshold of the heuristic
+score** (`t`, raised by ∆ until it reaches a win): sketch the proof outline
+cheaply, then fill in detail. Second — and this is the missing **4.2** answer —
+the manager is bootstrapped by a human-supplied line: *"From the human
+literature, a single 'best' line of play was identified and used to guide the
+initial foray of the manager… Without it, the manager may spend unnecessary
+effort looking for an important line to explore. The line leads from the start of
+the game into the endgame databases."* **FLIPHEX has no human literature.** There
+are no book openings, no expert lines, nothing to seed the manager with — the
+same "no domain knowledge" hole that R&N §6.3.2 identified for the evaluation
+function, reappearing in the scheduler. The obvious substitute is a policy from
+Axis 2: the learned network supplies the seed line that human masters supplied
+for checkers. That is a genuine, non-obvious cross-axis use of the learner — the
+solver consuming the learner's output rather than merely being checked against it
+— and it belongs in synthesis **S4**.
 
 ---
 
@@ -261,11 +611,63 @@ by direct search; and checksumming. This prompt is expected to produce a new ADR
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The paper treats correctness as a first-class engineering problem rather than a post hoc validation step. Because the computation spans many years and processes an enormous state space, the principal risk is not an obvious program failure but a subtle error that propagates unnoticed into the final proof. The authors therefore defend the result through multiple, complementary verification mechanisms rather than relying on confidence in a single implementation.
+
+The paper identifies several categories of potential failure, including algorithmic defects, hardware faults such as data transmission or storage errors, and implementation mistakes capable of silently corrupting intermediate or final results. To mitigate these risks, the project employed multiple layers of verification: extensive consistency checks during computation, independent re-verification of computed databases and proof components, and validation procedures designed to detect corruption even when the computation itself completed successfully. The underlying philosophy is that no single computation, regardless of scale, should be trusted without independent evidence supporting its correctness.
+
+For FLIPHEX, the same verification philosophy applies despite the much smaller state space. A complete 4×4 solution would enumerate approximately \(10^{11}\) states, making manual inspection impossible while allowing subtle implementation errors to produce entirely plausible—but incorrect—results. Consequently, correctness should be established through mutually reinforcing verification mechanisms rather than a single successful execution.
+
+Natural analogues include: (1) independently solving the complete 3×3 game using two fundamentally different methods (for example, exhaustive forward search and retrograde analysis) and requiring identical game-theoretic values; (2) enforcing global invariants over the database, such as the absence of draw values if the game rules mathematically preclude draws; (3) randomly selecting solved positions and independently re-deriving their values through direct search without consulting the database; (4) validating database integrity using cryptographic checksums or equivalent mechanisms to detect accidental corruption during storage or transmission; and (5) continuously checking structural consistency properties throughout database construction rather than only after completion.
+
+**Draft ADR Decision.** The FLIPHEX solver shall treat correctness as an explicit architectural concern rather than an implementation detail. No computed database or game-theoretic result shall be accepted solely on the basis of successful execution. Instead, correctness shall be established through independent verification, global invariant checking, integrity verification of stored data, and cross-validation against independently implemented reference solvers on tractable subproblems. The final solution shall be considered valid only if all verification mechanisms agree.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+The strongest section of the note, and the draft Decision is close to shippable —
+"no computed database or result shall be accepted solely on the basis of
+successful execution" is the right load-bearing sentence. Three additions, one of
+which is a verification FLIPHEX gets that checkers could not have.
+
+**Be careful attributing detail the paper does not give.** Your second paragraph
+reads as a catalogue drawn from the paper, but §5 is only four sentences long:
+sources of error (*"algorithm bugs and data transmission errors"*), *"verifying
+all computation results and doing consistency checks"*, and *"some of the
+computations have been independently verified"*. "Cryptographic checksums",
+"validation procedures designed to detect corruption" and "continuous structural
+consistency checking" are sensible engineering, but they are yours, not
+Schaeffer's — mark them as such or the note becomes a miscitation. The paper's
+*actual* redundancy mechanism is architectural and you can cite it: component 3
+uses **two different programs** on the same position, *"thus increasing the
+chances of obtaining a useful result"*.
+
+**FLIPHEX has a closed-form ground truth for a whole layer.** The terminal layer
+is only **3.4 × 10⁷ positions** (2²⁵ colourings, hands forced), and each one's
+value is decided by simply counting cells — no search, no recursion. So the entire
+base case of the retrograde pass can be verified exhaustively, in seconds, against
+a definition rather than against another implementation. Checkers had nothing
+comparable; its terminal set is not enumerable in closed form. That should be
+verification #0 in the ADR, because a bug in the base case silently poisons every
+layer above it.
+
+**Add layer-count verification — it catches the most likely bug class.** The
+number of positions in layer `t` is known in closed form
+(`C(25,t)·2^t·C(13,⌈t/2⌉)·C(12,⌊t/2⌋)`, modulo reachability). Counting what the
+enumerator actually produces per layer and comparing against the formula is the
+FLIPHEX analogue of chess's `perft`, and it detects the failure mode your list
+does not cover: not *wrong values*, but **missing or duplicated states**. A
+retrograde pass over an incomplete enumeration produces perfectly
+self-consistent, perfectly wrong answers, and would pass every check in your
+current draft. Note the subtlety that makes this doubly useful: the formula is an
+*upper* bound (the `2^t` factor assumes every colouring is reachable), so the gap
+between formula and actual count is itself the reachability measurement that
+§2.3 wants for calibrating `k`. One instrument, two jobs.
+
+Your no-draw invariant is the right instinct and worth stating in its strongest
+form: 25 is odd, so *every* terminal position has a strict winner, and a draw
+value appearing anywhere in the database is a proof of a bug — not evidence of
+one. That is a genuine theorem-backed assertion, cheap to check on every write.
+
+Add these three to the Decision paragraph and it is ready to become an ADR.
 
 ### 5.2 — What the authors do *not* claim
 **Prompt.** Read the correctness discussion adversarially. Is the claim "this is
@@ -276,11 +678,47 @@ specifically, what is the strongest sentence you are entitled to write about a
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The correctness discussion is deliberately cautious. The authors do not claim that the computation is infallible or that correctness has been established beyond all conceivable doubt. Instead, they argue that numerous independent verification procedures were designed to detect the classes of errors considered most plausible, and that these procedures consistently found no evidence of incorrectness.
+
+The distinction is important. The mathematical argument underlying the solver is exact, but the implementation executing that argument is a large software and hardware system that cannot itself be proven correct merely by producing an output. Consequently, the paper's confidence derives not from a single computation but from the convergence of multiple, largely independent sources of evidence supporting the same conclusion.
+
+This calibration has direct implications for FLIPHEX. A 4×4 result produced by a single implementation, executed once by a single researcher, should not be described as definitively proving the game-theoretic value of the initial position. Even if the algorithm is mathematically sound, the empirical evidence supporting the implementation remains limited.
+
+The strongest defensible claim under those conditions would be that the implementation computed a specific game-theoretic value and that no inconsistencies were detected by the verification procedures that were applied. Stronger language—such as claiming that the result has been conclusively proven—would require substantially broader evidence, including independent implementations, reproducibility across executions and platforms, comprehensive invariant checking, and systematic verification of the generated databases.
+
+Accordingly, the wording of H1 should remain proportional to the available evidence. Scientific claims should reflect not only the theoretical correctness of the algorithm but also the strength of the verification process supporting the computation.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+Nothing to correct — this is the most disciplined take in the note, and the
+distinction you draw (the *argument* is exact; the *system executing it* is not,
+and cannot be validated by producing output) is precisely the right one. Two
+things to bank.
+
+**The paper's own hedging is even more explicit than you found, and it is worth
+quoting in the writeup.** §7 concedes: *"Despite the convincing result, some
+mathematicians were skeptical, distrusting proofs that had not been verified using
+human-derived theorems"* and *"Although important components of the checkers proof
+have been independently verified, there may be skeptics."* Note what that second
+sentence admits — only *components*, not the whole, were independently verified,
+and the authors decline to claim the objection is answered. If a Science paper
+backed by 18 years and 50 machines writes that, the calibration for a solo project
+is set.
+
+**The sentence you are entitled to write, concretely.** Your final paragraph
+argues for proportionality but stops short of drafting it. Something like: *"An
+exhaustive retrograde enumeration of the 4×4 variant (deck per adr-009) assigns
+the initial position the value W. The computation passed all verification
+procedures in adr-0NN — closed-form terminal-layer check, per-layer state counts
+against the combinatorial formula, no-draw invariant, and agreement with an
+independent forward solver on the full 3×3 game and on a random sample of 4×4
+positions. It has not been independently reimplemented."* That last clause is what
+makes the rest credible, and it costs nothing.
+
+This also settles the wording question for **H1**: the verdict column should carry
+the *evidence class*, not just the verdict. "Supported (exact, single
+implementation, verified by N independent checks)" is honest and still strong.
+Worth building into `research.md`'s verdict table before the hypotheses lock.
 
 ---
 
@@ -303,11 +741,58 @@ answer differ between 4×4 and 5×5?
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The paper's guiding principle is to determine the game-theoretic value of the initial position while performing only the computation that is logically necessary for the proof. This philosophy is reflected in the treatment of opening positions.
+
+Approximately 300 distinct three-move openings were initially considered. More than one hundred of these were eliminated because they were equivalent through transpositions, reducing the number of genuinely distinct opening positions. The remaining openings were then analyzed by alpha-beta search. For many of them, the search established that their exact game-theoretic values could not influence the proof of the initial position. These openings were therefore classified as irrelevant, leaving only nineteen openings whose values had to be determined explicitly.
+
+The term "irrelevant" has a precise logical meaning. It does not imply that the positions are uninteresting or unsolved. Rather, it means that the proof of the initial position can already be completed without computing their exact values. Alpha-beta establishes bounds sufficient to show that these branches cannot alter the minimax value propagated to the root. Once this has been proven, further computation on those branches cannot change the final theorem and is therefore unnecessary.
+
+The same principle is applicable to FLIPHEX, although the available reductions differ. Transpositions remain a natural source of reduction whenever different move orders produce identical game states. Geometric symmetries can also reduce the root branching factor, but only when the game rules preserve those symmetries. According to ADR-008, the board mirror symmetry is only partially valid because of the known chiral pattern P3-y. Consequently, symmetry reduction cannot be applied indiscriminately at the root and must be restricted to positions for which equivalence has been formally established.
+
+The alpha-beta notion of irrelevance is the most generally transferable idea. To prove the value of the initial position, it is unnecessary to compute the exact value of every branch. It is sufficient to establish bounds showing that certain branches cannot affect the root minimax value. This reduction depends on logical implication rather than on game-specific structure.
+
+Whether FLIPHEX admits an analogue of the nineteen critical openings remains an open empirical question. A substantial reduction appears plausible for the 4×4 game, where exhaustive analysis is comparatively tractable. For the full 5×5 game, however, the much larger branching factor and the absence of the converging structure exploited in checkers make it difficult to predict comparable reductions without experimental evidence. The paper therefore motivates searching for such a critical subset but does not justify assuming that one necessarily exists.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+The definition of "irrelevant" is exactly right — bounds, not values; logical
+implication, not disinterest — and refusing to assume a FLIPHEX analogue exists is
+the correct scientific posture. But there is a structural reason it *cannot* exist
+in the form Schaeffer used, and it comes from the one FLIPHEX property you have
+been treating as an unmixed blessing.
+
+**No draws means no partial proofs.** Look at what the solver is allowed to
+return: *"proven (win, loss, draw), **partially proven (at least a draw, at most a
+draw)**, or heuristic."* That middle category is the engine of the whole "least
+work" argument. Checkers' root value is a *draw*, so to discharge an opening you
+need only bound it — show it is "at least a draw" for one side, "at most a draw"
+for the other — and you never compute its exact value. Partial proofs are cheap;
+full proofs are not.
+
+FLIPHEX has no draw. The value set is `{win, loss}`, and on a two-element totally
+ordered set **a bound is the value**: "at least a win" *is* a win; "at most a
+loss" *is* a loss. There is no intermediate rung to bound against, so the
+partially-proven category is empty by construction and every opening you touch
+must be resolved outright. The alpha-beta cutoff still works within a search — α
+and β still prune — but the *cross-opening* economy that reduced ~300 checkers
+openings to 19 has no FLIPHEX counterpart.
+
+So the honest catalogue of reductions available at a FLIPHEX root is shorter than
+your take implies: transpositions (real, and large — the tree/state-space gap is
+~10⁴³ on 5×5), and the Z/2 mirror (real but *unavailable at the root*, since
+adr-008 makes it conditional on both chiral `P3-y` tiles being placed — which by
+definition has not happened at ply 1). The third mechanism, bounding against an
+intermediate value, is simply not there. 1450 openings on 5×5, roughly 725 after a
+mirror fold that you cannot legally apply yet.
+
+This is the second time in this note that "draws are impossible" cuts both ways —
+it collapses the backward pass to a single sweep (§2.1) and it removes the
+forward proof's main economy here. Both belong in the ADR, because the project has
+so far treated no-draws purely as a simplification. It is not; it is a trade.
+
+On 4×4 the point is moot: a full enumeration needs no opening reduction at all.
+The asymmetry only bites on 5×5, which is exactly where §3.1 concluded the
+meet-in-the-middle architecture already fails.
 
 ### 6.2 — The resource budget, honestly compared
 **Prompt.** Collect the cost figures the paper gives: years elapsed, number of
@@ -319,11 +804,57 @@ FLIPHEX 3×3, 4×4 (reduced deck), 5×5 endgame `k ≤ 3`, 5×5 full solve.
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The paper presents the checkers solution as the culmination of approximately eighteen years of research. The computation relied on substantial computational infrastructure, including multiple generations of hardware, parallel processors, and large endgame databases whose construction and verification required significant storage and processing resources. Different components of the pipeline were developed and executed over different periods, with the endgame databases preceding the final proof construction by several years.
+
+The scale of these resources should not be interpreted as an intrinsic requirement of the underlying algorithms. Retrograde analysis, alpha-beta search, database construction, and proof verification are fundamentally sequential algorithms with natural opportunities for parallel decomposition rather than inherently distributed algorithms. The use of multiple processors primarily reflects the size of the checkers state space and the practical desire to reduce computation time.
+
+For FLIPHEX, the engineering picture differs substantially. Database indexing, retrograde propagation, proof-tree construction, and correctness verification all transfer directly as algorithmic ideas. Their implementation on a single workstation is primarily limited by memory capacity, storage bandwidth, and execution time rather than by any fundamental requirement for distributed computation.
+
+A realistic feasibility assessment is therefore:
+
+- **FLIPHEX 3×3:** Clearly feasible on a single laptop. Independent verification by multiple algorithms is also practical.
+- **FLIPHEX 4×4 (reduced deck):** Feasible on a modern workstation or laptop, provided that storage layout, indexing, and I/O are carefully engineered. The principal challenge is implementation quality rather than computational scale.
+- **FLIPHEX 5×5 endgame (k ≤ 3):** Plausibly feasible on a single machine, although execution time and storage management become significant engineering concerns. Experimental validation is required.
+- **FLIPHEX 5×5 full solve:** The current evidence does not justify claiming feasibility. Although the estimated state-space size is substantially smaller than that of checkers, the diverging structure of the game implies that state-space size is not the limiting factor. Based on the arguments developed throughout the paper, the principal uncertainty lies in structural coverage rather than computational capacity.
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+The verdicts are sound and the key judgement — that cluster scale reflects
+checkers' *size*, not an intrinsic property of the algorithms — is right and
+important. Put the paper's actual figures behind it, because vague scale is what
+makes people over- or under-estimate this kind of project:
+
+| | figure |
+|---|---|
+| Project span | 1989–2007 (18 years) |
+| 8-piece databases | 7 years (1989–1996); **the same computation took one month in 2001** |
+| 10-piece databases | finished 2005; 3.9 × 10¹³ positions, 237 GB compressed |
+| Processors | 200+ simultaneously in 1992; *"over the past year, we averaged using 50 computers continuously"* |
+| Stored proof tree | 10⁷ positions |
+| Forward search effort | ~10¹⁴ nodes |
+
+The one-month-versus-seven-years line is the most useful number in the paper for
+this project: the *same* computation, 84× faster, from hardware and algorithmic
+improvement over five years. Nineteen more years have passed. A large part of what
+looks like cluster-scale in 2007 is a laptop in 2026, and that supports your
+feasibility verdicts more concretely than the general argument does.
+
+Two corrections. **The 5×5 full-solve verdict cites the wrong reason.** You
+attribute it to "the diverging structure" and "structural coverage" — but per the
+corrected §2.2, the endgame layer is *narrow* and the database is feasible; what
+fails is that its reach is rigidly capped at `k` plies while the forward proof
+must descend from b = 1450. Name game-tree complexity (~10⁶¹, ~10³⁰·⁵ even at the
+`b^{d/2}` limit) as the binding quantity. **And the `k ≤ 3` verdict is now too
+conservative**: at Schaeffer's compression ratio that slice is ~61 GB, not a
+storage problem at all. The open question there is compressibility, not capacity —
+which is the experiment flagged in §2.3.
+
+Revised one-liners:
+
+- **3×3** — trivially feasible; use it as the two-method cross-validation fixture (§5.1).
+- **4×4 (reduced deck)** — feasible on a laptop. ~9.3 × 10¹⁰ states; 23 GB at 2 bits, plausibly under 1 GB compressed. Engineering quality, not scale, is the risk.
+- **5×5 endgame k ≤ 3** — comfortably feasible (~9 × 10¹² positions, ~61 GB compressed). `k ≤ 4` becomes a ~1 TB question and is worth attempting; `k ≤ 5` needs measured compression before it is promised.
+- **5×5 full solve** — out of reach, and the reason is the forward proof, not storage. Worth stating in adr-004 with the number, since "we checked and here is the quantity that stops us" is a stronger claim than "almost certainly not".
 
 ---
 
@@ -340,7 +871,11 @@ that a strong learned agent does not?
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The paper argues that solving checkers has significance beyond the game itself. The result demonstrates that long-term advances in artificial intelligence, large-scale search, database construction, and parallel computing can be integrated into a computation that produces a mathematically justified result. The authors also emphasize that techniques developed for this project have applications outside game playing, including problems in bioinformatics and other domains requiring large-scale combinatorial search.
+
+The comparison with Deep Blue further clarifies the contribution. Whereas Deep Blue demonstrated that a machine could defeat the strongest human players, the checkers project establishes the game-theoretic value of the game itself. The scientific contribution is therefore not superior playing strength but a provably correct characterization of the game under perfect play.
+
+For FLIPHEX, an exact 4×4 solution provides something that a learned agent cannot: a mathematically justified oracle for the game-theoretic value of every solved position within its scope, enabling exact validation of algorithms, hypotheses, and future approximations.
 
 **Refined write-up.**
 
@@ -358,7 +893,13 @@ answer? Feed the tension into **S4**.
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The paper treats the game-theoretic value of checkers as the primary scientific objective. Once the initial position has been proven to be a draw under perfect play, the central research question has been answered. The solve transforms the game into a mathematically characterized object.
+
+For the FLIPHEX project, however, the exact value of the initial position is not the final objective but an enabling result. A root win/loss/draw verdict establishes the game-theoretic outcome, but it does not explain why that outcome occurs, which strategic features determine it, or how alternative game designs would affect it.
+
+Consequently, an exact solution directly supports H1 by establishing the game-theoretic value of the initial position and provides an oracle for subsequent experiments. However, it does not by itself answer questions about deck balance (H5) or counterfactual robustness (H6). Those hypotheses require comparative analyses across multiple game variants, structural examination of proof trees or solved databases, and counterfactual experimentation beyond the original solved game.
+
+Thus, for FLIPHEX, the solve should be viewed as foundational infrastructure rather than the endpoint of the research program.
 
 **Refined write-up.**
 
@@ -368,8 +909,20 @@ _(preencho depois que você compartilhar seu take)_
 
 ## Lessons Learned
 
-_(filled at merge — what changed in how I think about exact solving.)_
+his reading fundamentally changed my understanding of exact game solving. I initially viewed retrograde analysis as the primary algorithm and alpha-beta search as a separate optimization. Schaeffer instead presents them as two complementary halves of a single proof: backward analysis establishes exact game-theoretic values over a solved region of the state space, while forward search constructs the proof that the initial position reaches that region without ever relying on heuristic evaluation.
+
+Another important shift was recognizing that the feasibility of an exact solve depends less on raw state-space size than on the structure of the game graph. The checkers result is enabled by convergence: progressive piece reduction forces play into a relatively small family of solved endgames. This provides a much stronger explanation than simply comparing state counts, and reframes how I should evaluate the prospects of solving FLIPHEX.
+
+The paper also expanded my view of what constitutes a computational proof. Correctness is not guaranteed merely because the underlying algorithm is mathematically sound. Verification, independent rechecking, consistency testing, and data integrity become architectural concerns rather than implementation details. A solver is not only an algorithm but an evidence-producing system.
+
+Finally, I came to see an exact solve as research infrastructure rather than the endpoint of a project. A solved game provides an oracle for validation, experimentation, and future analysis, but the game-theoretic value of the initial position alone does not explain strategy, balance, or design decisions.
 
 ## Failed Attempts
 
-_(filled at merge — revised assumptions, reading dead-ends.)_
+I initially assumed that the published result would be a strong solution because of the extensive retrograde databases. The paper explicitly claims a weak solution, reminding me to distinguish the capabilities of individual components from the formal claim made by the authors.
+
+I also tended to compare games primarily through state-space size. The reading showed that this is an incomplete metric: structural properties such as convergence, decomposition, and proof coverage are often more important than the total number of reachable positions.
+
+Another early assumption was that retrograde databases alone constituted the solution. The paper demonstrates that they are only one half of the proof; the forward proof tree is equally essential because it connects the initial position to the solved region.
+
+Finally, I occasionally conflated a proof tree with the Knuth–Moore minimal search tree and treated proof-oriented search as synonymous with Proof-Number Search. The paper supports neither equivalence. These concepts are closely related but address different questions: complexity bounds, proof representation, and search strategy.

--- a/notes/schaeffer-2007-checkers-is-solved.md
+++ b/notes/schaeffer-2007-checkers-is-solved.md
@@ -524,7 +524,36 @@ For ADR-004, this paper provides additional motivation to reconsider the earlier
 
 **Refined write-up.**
 
-_(preencho depois que você compartilhar seu take)_
+The manager/solver split and the existential-vs-universal asymmetry are correct,
+and the Knuth–Moore distinction is the sharpest thing in the note: the minimal
+tree is a *complexity bound*, the proof tree is a *certificate*. Keep that
+wording verbatim. But the claim that decides the ADR question is wrong.
+
+**Proof-number search is not absent from this paper — it is the manager's core
+algorithm.** The text: *"The manager maintains the master copy of the proof, and
+identifies a prioritized list of positions that need to be examined **using the
+Proof Number search algorithm** (6)."* Reference (6) is Allis. The paper also
+names the **Df-pn** variant — *"builds the search tree in a depth-first manner,
+requiring less computer storage"*. So the largest game-solving result ever
+published uses PN-search as the scheduler deciding *what to prove next*, with
+alpha-beta (Chinook, 17–23 ply) as the solver underneath. Your sentence "the
+paper does not describe the manager as implementing PNS" inverts this.
+
+**This forces a correction to something I wrote, not only to your take.** The
+adr-004 Phase 2 amendment argued that pn-search "loses its structural edge" on
+FLIPHEX because pn-search shines on *sudden-death* goal-proving while FLIPHEX is
+fixed-termination. Checkers is **also fixed-termination** (Allis classifies it
+so), and pn-search is central to its proof anyway. That argument was wrong as
+stated and the amendment needs rewriting.
+
+What survives is a distinction the ADR currently conflates. adr-004 rejected
+pn-search *as a replacement search paradigm* — a second full engine to build,
+debug and explain on top of a three-axis project. **That rejection still stands.**
+What adr-004 never considered is pn-search in Schaeffer's actual role: a **work
+scheduler over a proof tree**, sitting above ordinary alpha-beta solvers, which is
+a much smaller commitment. Those are two different decisions. Your closing
+sentence lands on the right verdict — reopened as a scoped extension, not adopted
+— and it is now better supported than you knew when you wrote it.
 
 ### 4.2 — Where the effort actually went
 **Prompt.** The paper describes the manager choosing which positions to expand
@@ -546,55 +575,66 @@ For FLIPHEX, the situation depends on the solver architecture. A pure retrograde
 
 **Refined write-up.**
 
-*(Note: this answers prompt **4.1**, not 4.2 — 4.1's slot above is still empty and
-4.2's actual question, about the manager's failure mode, is unanswered. Worth
-moving this text up; the missing 4.2 answer is sketched at the end here.)*
+The scheduling framing is right — "the objective is not simply to prove positions,
+but to allocate computation so that the overall proof is completed with minimal
+total work" is the sentence the paper is making — and the FLIPHEX verdict at the
+end is correct. But the prompt asked you to *retrieve* the truncated sentence, and
+you reconstructed it instead. The reconstruction is plausible and wrong, in a way
+worth noticing.
 
-The manager/solver split and the existential-vs-universal asymmetry are correct,
-and the Knuth–Moore distinction is the sharpest thing in the note: the minimal
-tree is a *complexity bound*, the proof tree is a *certificate*. Keep that
-wording. But the claim that decides the ADR question is wrong.
+**The real passage.** From the PDF (the extraction interleaves the columns here):
 
-**Proof-number search is not absent from this paper — it is the manager's core
-algorithm.** The text: *"The manager maintains the master copy of the proof, and
-identifies a prioritized list of positions that need to be examined **using the
-Proof Number search algorithm** (6)."* Reference (6) is Allis. The paper also
-names the **Df-pn** variant — *"builds the search tree in a depth-first manner,
-requiring less computer storage"*. So the largest game-solving result ever
-published uses PN-search as the scheduler that decides *what to prove next*, with
-alpha-beta (Chinook, 17–23 ply) as the solver underneath.
+> "From the human literature, a single 'best' line of play was identified and used
+> to guide the initial foray of the manager into the depths of the search tree.
+> Although not essential for the proof, this is an important performance
+> enhancement. It allows the proof process to immediately focus its work on the
+> parts of the search space that are likely to be relevant. **Without it, the
+> manager may spend unnecessary effort looking for an important line to explore.**
+> The line leads from the start of the game into the endgame databases."
 
-This forces a correction to something **I** wrote, not just to your take. The
-adr-004 Phase 2 amendment argued that pn-search "loses its structural edge" on
-FLIPHEX because pn-search shines on *sudden-death* goal-proving and FLIPHEX is
-fixed-termination. Checkers is **also fixed-termination** (Allis classifies it
-so), and pn-search is central to its proof anyway. That argument was wrong as
-stated.
+You read the failure mode as *"the manager may spend unnecessary effort searching
+for an alternative proof even though a sufficient proof already exists elsewhere
+in the tree"* — i.e. redundant work on a solved problem. The actual failure mode
+is the opposite and worse: without a seed line, the manager has **no spine to work
+along at all**, and wastes effort *finding somewhere worth working*. The waste is
+at the start, not the margin. Note also what the seed line *is*: a path "from the
+start of the game into the endgame databases" — a hand-supplied hypothesis about
+where the two ends meet, which is exactly the junction §3.1 identified as the
+whole architecture.
 
-What survives, and is the right distinction: adr-004 rejected pn-search *as a
-replacement search paradigm* — a second full engine to build, debug and explain.
-That rejection still stands. What adr-004 never considered is pn-search in
-Schaeffer's actual role: a **work scheduler over a proof tree**, sitting above
-ordinary alpha-beta solvers. Those are different decisions and the ADR conflates
-them. The amendment should be corrected to say so, and the honest verdict is your
-last sentence — reopened as a scoped extension, not adopted.
+**And this is the part that matters for FLIPHEX: there is no human literature.**
+No opening book, no master games, no expert lines — the game has been played by a
+handful of people. So the one bootstrap Schaeffer describes as "an important
+performance enhancement" is simply unavailable. This is the same "no domain
+knowledge" hole R&N §6.3.2 found in the evaluation function, reappearing one level
+up in the scheduler, and it is a *third* place where FLIPHEX's novelty costs it
+something concrete.
 
-Two more things the paper gives that belong in the ADR's thinking. First, the
-manager iterates not on depth but **on the error threshold of the heuristic
-score** (`t`, raised by ∆ until it reaches a win): sketch the proof outline
-cheaply, then fill in detail. Second — and this is the missing **4.2** answer —
-the manager is bootstrapped by a human-supplied line: *"From the human
-literature, a single 'best' line of play was identified and used to guide the
-initial foray of the manager… Without it, the manager may spend unnecessary
-effort looking for an important line to explore. The line leads from the start of
-the game into the endgame databases."* **FLIPHEX has no human literature.** There
-are no book openings, no expert lines, nothing to seed the manager with — the
-same "no domain knowledge" hole that R&N §6.3.2 identified for the evaluation
-function, reappearing in the scheduler. The obvious substitute is a policy from
-Axis 2: the learned network supplies the seed line that human masters supplied
-for checkers. That is a genuine, non-obvious cross-axis use of the learner — the
-solver consuming the learner's output rather than merely being checked against it
-— and it belongs in synthesis **S4**.
+The obvious substitute is a policy from **Axis 2** — the learned network supplying
+the seed line that human masters supplied for checkers. That is a genuine
+cross-axis use of the learner, with the solver *consuming* its output rather than
+merely being checked against it, and adr-004's independence principle has never
+been tested against it. It is now synthesis **S6**; do not settle it here.
+
+**Your FLIPHEX verdict is right, and §3.1 makes it stronger than you claimed.**
+You said a pure 4×4 retrograde enumeration has essentially no scheduling problem
+("every reachable position must eventually be processed exactly once") — correct,
+and per §2.1 the layers are processed in strict ply order, so there is not even a
+choice of *which layer* next. You then hedge that a meet-in-the-middle 4×4 solver
+would inherit the scheduling problem. It would, but per §3.1 that architecture is
+*unnecessary* on 4×4 (full enumeration already solves the whole board) and
+*unavailable* on 5×5 (the two ends cannot be made to meet). So the hedge describes
+a configuration the project should not build. The clean statement: **FLIPHEX's
+exact solve has no scheduling problem, because it is enumeration rather than
+proof** — and that is a real simplification worth stating in adr-004, not a gap.
+
+One more scheduling idea from the paper worth banking even though it does not
+transfer: the manager iterates not on depth but **on the error threshold of the
+heuristic score** — assume all scores ≥ `t` are wins and ≤ −`t` are losses, prove
+the result under that assumption, then raise `t` by ∆ and repeat. Sketch the proof
+outline cheaply at low `t`, flesh out details later. It is an elegant answer to
+"where do I start when everything is unproven", and it needs a heuristic FLIPHEX
+does not have — which is the same hole again, for the third time in one prompt.
 
 ---
 

--- a/notes/schaeffer-2007-checkers-is-solved.md
+++ b/notes/schaeffer-2007-checkers-is-solved.md
@@ -1,0 +1,375 @@
+# Reading companion — Schaeffer et al. 2007, Checkers Is Solved
+
+**Citation.** Schaeffer, J., Burch, N., Björnsson, Y., Kishimoto, A., Müller, M.,
+Lake, R., Lu, P. & Sutphen, S. (2007). *Checkers Is Solved.* **Science**
+317(5844), 1518–1522. DOI [10.1126/science.1144079](https://doi.org/10.1126/science.1144079).
+Read from the Science Express version (`refs/schaeffer-2007-checkers-is-solved.pdf`,
+9 pp).
+
+**Why this source, and where it sits.** This is the **only published account of
+the exact pipeline the FLIPHEX solver has turned into**. The R&N reading
+established that the 4×4 exact solve is not a tree-search problem at all — the
+perfect-ordering alpha-beta bound is ~10¹⁶·⁵ while the state space is ~10¹¹, so
+what solves it is *enumeration plus lookup*, and the binding constraint is
+storage and I/O ([adr-004](docs/adr/adr-004-solver-approach.md) §6.3.1 of the
+[R&N note](notes/russell-norvig-aima-ch6-adversarial-search.md)). Schaeffer is
+the reference implementation of exactly that idea at scale: retrograde endgame
+databases from the bottom, a proof tree from the top, meeting in the middle, run
+for 18 years and defended as a *proof*. Read it **last** in Phase 2 — it assumes
+Allis's solved-taxonomy vocabulary and answers the engineering question R&N only
+gestures at in §6.3.4.
+
+**Directed reading.** The paper is short and every part earns its place; there is
+no section to skip. Weight your time toward **Backward search**, **Correctness**,
+and **Results** — those three carry everything that transfers. The *Supporting
+Online Material* section (§4 of the extraction) has the database-construction
+detail and is worth a skim if §2's account leaves the retrograde algorithm fuzzy.
+
+**Cross-refs this reading feeds:**
+- [adr-004](docs/adr/adr-004-solver-approach.md) — the whole exact-solve strategy:
+  the retrograde databases, the `k` target, and (new) whether the 4×4/5×5 solve
+  should be a *backward + forward hybrid* rather than either alone.
+- [adr-009](docs/adr/adr-009-reduced-deck-policy.md) — the reduced deck exists to
+  put 4×4 inside enumeration range; Schaeffer calibrates what "in range" means.
+- [research.md](docs/research.md) — **H1** (what class of claim the verdict is),
+  **H3** (the solver as oracle), **H4** (where FLIPHEX sits on the complexity
+  ladder — checkers is a datapoint *above* it).
+- [allis-1994 note](notes/allis-1994-searching-for-solutions.md) — the
+  converging/diverging distinction, which is the crux of prompt 2.2 below.
+- [russell-norvig note](notes/russell-norvig-aima-ch6-adversarial-search.md) —
+  §6.3.4 (search versus lookup) is the textbook sketch of this paper.
+- `exercises/` — the retrograde-analysis derivation belongs here.
+- **New:** there is currently **no ADR covering solver correctness**. Prompt 5.1
+  is likely to create one.
+
+**Legend.** Prompts marked 🔄 need synthesis with another source — answer them in
+[phase2-synthesis.md](notes/phase2-synthesis.md) (**S1**: what "solved" buys;
+**S4**: exact solving vs learned play), not here.
+
+**Reading material** (extracted via `paper-study`, gitignored under
+`notes/sources/`).
+[manifest](sources/schaeffer-2007-checkers-is-solved/manifest.json) ·
+[§1 front matter](sources/schaeffer-2007-checkers-is-solved/sections/01-front-matter.md) ·
+[§2 main text](sources/schaeffer-2007-checkers-is-solved/sections/02-checkers-is-solved.md) ·
+[§3 references](sources/schaeffer-2007-checkers-is-solved/sections/03-references-and-notes.md) ·
+[§4 supporting online material](sources/schaeffer-2007-checkers-is-solved/sections/04-supporting-online-material.md).
+
+> **Extraction note.** The two-column Science Express layout defeated the
+> heading splitter, so the whole body is one 4774-word file (§2). Navigate it by
+> the paper's own bold run-in heads, which are intact:
+
+| This note's prompt | Anchor in `02-checkers-is-solved.md` |
+|---|---|
+| §1 framing and result | opening paragraphs (before `**Backward search.**`) |
+| §2 retrograde databases | `**Backward search.**` (line ~42) |
+| §3 architecture | `**Solving checkers.**` (line ~54) |
+| §4 proof tree | `**Forward search.**` (line ~79) |
+| §5 correctness | `**Correctness.**` (line ~91) |
+| §6 results and cost | `**Results.**` (line ~97) |
+| §7 conclusion 🔄 | `**Conclusion.**` (line ~124) |
+
+> Lines around 32 are garbled — the extractor interleaved the two columns there.
+> If a sentence reads as nonsense, check the PDF rather than trusting the file.
+
+---
+
+## §1 — What was proved, and in what class
+
+### 1.1 — The claim, stated precisely
+**Prompt.** The abstract says "checkers is now solved: perfect play by both sides
+leads to a draw." In Allis's taxonomy, which class is that — ultra-weak, weak, or
+strong? Find the sentence in the paper that pins it down (the authors are explicit;
+do not infer it). Then the FLIPHEX consequence: **H1** asks who wins from the
+initial position, so which class does H1 need — and does the retrograde route
+planned for 4×4 deliver *more* than H1 asks for? Predict before reading: do you
+expect the strongest published game-solving result to be a strong solution?
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+### 1.2 — The complexity comparison, and a number that should unsettle you
+**Prompt.** The paper gives checkers ~5 × 10²⁰ positions and calls it "roughly one
+million times more complex than Connect Four". Now put FLIPHEX 5×5 next to it:
+the corrected reachable bound is **4.9 × 10¹⁷** ([research.md](docs/research.md)),
+i.e. checkers is ~1000× *larger* than the full FLIPHEX game. Sit with that. If a
+bigger game was solved in 2007, what stops FLIPHEX 5×5 from being solved now?
+List every reason you can find in the paper before reading §2 — then check your
+list against prompt 2.2, which contains the answer you probably missed. This
+directly stress-tests **H4** and the adr-004 claim that "the full 5×5 game will
+almost certainly not be solved."
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+---
+
+## §2 — Backward search: the endgame databases
+
+### 2.1 — Retrograde analysis, mechanically
+**Prompt.** Write the algorithm as the paper describes it: start from 1-piece
+positions, enumerate and resolve 2-piece, then 3-piece, and so on to ≤10 pieces.
+Two things to extract precisely: (a) how a position's value is *derived* from
+already-resolved positions (what is the backward analogue of the minimax
+max/min step?); (b) how **draws by repetition** are detected, since a
+repeated position has no resolved successor — this is the part that makes
+retrograde analysis harder than it first looks. Then: FLIPHEX has **no draws and
+no repetition** (25 cells, one filled per ply, odd). Which of these complications
+simply vanishes for FLIPHEX, and does that make the FLIPHEX retrograde pass
+*simpler* than checkers' or merely different?
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+### 2.2 — Convergence: why this worked for checkers and may not for FLIPHEX
+**Prompt.** *This is the load-bearing prompt of the whole note.* The paper notes
+that "the checkers forced-capture rule quickly results in many pieces being
+removed from the board, giving rise to a position with ≤10 pieces – and a known
+value." Checkers is a **converging** game: the state gets *smaller* as play
+proceeds, so the endgame is a narrow funnel every line must pass through.
+FLIPHEX is **diverging** — a tile is added every ply, so the endgame is the
+*widest* part of the state space, not the narrowest. Allis says endgame databases
+are "generally unfeasible for diverging" games.
+
+Answer three things. (a) Restate in your own words why convergence is what makes
+a 10-piece database *cover* the game rather than just decorate it. (b) For
+FLIPHEX, the last-`k`-empty slice grows explosively going backwards: k≤3 ≈
+9 × 10¹², k≤4 ≈ 1.5 × 10¹⁴, k≤5 ≈ 1.2 × 10¹⁵ (upper bounds). Compare with
+checkers' ≤10-piece database size, which the paper gives — is FLIPHEX's `k ≤ 5`
+target above or below what an 18-year multi-machine project achieved? (c) Given
+(a) and (b), is the answer to prompt 1.2 that FLIPHEX 5×5 *is* within reach, or
+that raw state count was never the binding constraint? State which, and why.
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+### 2.3 — Storage, indexing and compression
+**Prompt.** Retrograde analysis is an I/O problem before it is a search problem.
+Find what the paper (and the supporting online material) says about how the
+databases are **stored, indexed, and compressed**, and about the distinction
+between what is kept on disk and what is recomputed. FLIPHEX's 4×4 solve is
+~9.3 × 10¹⁰ states ≈ 23 GB at 2 bits each — squarely in the regime where these
+choices decide feasibility. Which specific techniques would transfer, and which
+depend on checkers-specific structure (piece counts, symmetry) FLIPHEX lacks?
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+---
+
+## §3 — The architecture: backward and forward meeting in the middle
+
+### 3.1 — The three components, and the shape of the proof
+**Prompt.** The paper lists the proof procedure's three algorithm/data components.
+Name them and draw the picture: the endgame databases growing *up* from the end,
+the proof tree growing *down* from the opening, and what happens where they meet.
+Why is this a **proof** rather than merely very strong play — what exactly is the
+logical claim at the junction? Then map it onto adr-004, which already has the
+same two halves (retrograde DBs + alpha-beta) but currently describes them as
+*independent* deliverables rather than as two ends of one proof. Should adr-004
+be rewritten around the meet-in-the-middle framing? Argue both sides.
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+---
+
+## §4 — Forward search: the proof tree
+
+### 4.1 — Proof-tree manager and solvers, and "least work"
+**Prompt.** Describe the split between the proof-tree manager (which decides
+*what* to prove) and the solvers (which prove individual positions). The key idea
+is that a proof tree is **much smaller than a full search tree** — you need only
+one refutation per opponent move, but all moves for your own. Connect this to the
+`b^{d/2}` result in the [R&N note](notes/russell-norvig-aima-ch6-adversarial-search.md)
+§6.3.1: is the proof tree the *same* object as the Knuth–Moore minimal tree, or
+something different? Then: adr-004 parked proof-number search as "a good
+extension if the paper track activates" — does this paper reopen that decision?
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+### 4.2 — Where the effort actually went
+**Prompt.** The paper describes the manager choosing which positions to expand
+and notes it "may spend unnecessary effort looking for an" (see the paper — the
+extraction garbles this passage). Get the real sentence and capture the failure
+mode being described. What does this say about the *scheduling* problem in a long
+exact computation, and does FLIPHEX's 4×4 solve have an analogous choice, or is
+it a single undifferentiated enumeration pass?
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+---
+
+## §5 — Correctness: how you defend an 18-year computation
+
+### 5.1 — The verification discipline (the section nobody expects to need)
+**Prompt.** The authors ask "Are the results correct?" and list the defences:
+sources of error they anticipated (algorithm bugs, data transmission errors),
+verification of computation results, consistency checks, and independent
+re-verification. Catalogue them precisely.
+
+Then the FLIPHEX question, which currently has **no ADR and no answer**: the 4×4
+solve will be a ~10¹¹-state enumeration whose output is a single verdict for H1.
+Nobody can eyeball it, and a silent bug produces a *plausible* wrong answer, not
+a crash. What would the FLIPHEX analogue of each defence be? Consider at least:
+solving 3×3 by two independent methods and requiring agreement; invariants that
+must hold across the whole database (e.g. no draws — 25 cells is odd, so *any*
+draw value anywhere is a proof of a bug); re-deriving a random sample of entries
+by direct search; and checksumming. This prompt is expected to produce a new ADR
+— draft its Decision section here in one paragraph.
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+### 5.2 — What the authors do *not* claim
+**Prompt.** Read the correctness discussion adversarially. Is the claim "this is
+proved correct" or "we have taken great care and found no errors"? Note the exact
+hedging. How should that calibrate the wording of FLIPHEX's own H1 verdict —
+specifically, what is the strongest sentence you are entitled to write about a
+4×4 result produced by one implementation, run once, by one person?
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+---
+
+## §6 — Results and cost
+
+### 6.1 — The 19 openings, and solving by doing the least work
+**Prompt.** The stated approach is "to determine the game-theoretic result by
+doing the least amount of work." Unpack the concrete instance: ~300 three-move
+openings, over 100 duplicates by transposition, the rest "proven to be irrelevant
+by an Alpha-Beta search", leaving **19** to be solved outright. Explain what
+"irrelevant" means here — it is a precise claim, not hand-waving.
+
+Now FLIPHEX: ply 1 has **1450** legal moves. What are the available reductions?
+Consider (a) transpositions, (b) the Z/2 board mirror — but note
+[adr-008](docs/adr/adr-008-board-mirror-symmetry.md) says it is only a *partial*
+symmetry while a chiral `P3-y` is in hand, so be careful about when it applies at
+the root, and (c) the alpha-beta "irrelevance" argument above, which needs only a
+*bound*, not a value. Is there a FLIPHEX analogue of "19 openings", and does the
+answer differ between 4×4 and 5×5?
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+### 6.2 — The resource budget, honestly compared
+**Prompt.** Collect the cost figures the paper gives: years elapsed, number of
+machines/processors, the database sizes, when each phase ran. Then do the honest
+comparison: FLIPHEX is a solo laptop project. Which parts of this pipeline are
+*inherently* parallel-cluster-scale and which are only so because checkers is
+1000× larger than FLIPHEX 5×5? Produce a one-line feasibility verdict for each of:
+FLIPHEX 3×3, 4×4 (reduced deck), 5×5 endgame `k ≤ 3`, 5×5 full solve.
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+---
+
+## §7 — Conclusion and limits
+
+### 7.1 — What the authors say the result means 🔄
+**Prompt.** The Conclusion reflects on the scientific significance — note the
+framing (AI + parallel computing, the bioinformatics transfer, the DEEP BLUE
+comparison). What do the authors claim solving a game *buys*, beyond the game?
+This is synthesis **S1** — put the cross-source argument there (Allis's "which
+games will survive", R&N §6.7's four limitations, and this) and here only record
+the one-line answer for FLIPHEX: what does an exact 4×4 verdict buy the project
+that a strong learned agent does not?
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+### 7.2 — The limitation this paper does not dwell on 🔄
+**Prompt.** Checkers was solved and is now, in a real sense, a finished object.
+The paper is upbeat about that. Read against it: what does the *design-study*
+thesis of this project ([research.md](docs/research.md)) want from a solve —
+strategy knowledge, balance verdicts, design feedback — and does a
+win/loss/draw value at the root actually deliver any of it? A solved game tells
+you the value; it does not tell you *why*. Where does that leave H5 (deck
+balance) and H6 (counterfactual robustness), neither of which a root value can
+answer? Feed the tension into **S4**.
+
+**My take.**
+
+_(você escreve, em primeira pessoa)_
+
+**Refined write-up.**
+
+_(preencho depois que você compartilhar seu take)_
+
+---
+
+## Lessons Learned
+
+_(filled at merge — what changed in how I think about exact solving.)_
+
+## Failed Attempts
+
+_(filled at merge — revised assumptions, reading dead-ends.)_

--- a/notes/schaeffer-2007-checkers-is-solved.md
+++ b/notes/schaeffer-2007-checkers-is-solved.md
@@ -43,8 +43,9 @@ detail and is worth a skim if §2's account leaves the retrograde algorithm fuzz
   is likely to create one.
 
 **Legend.** Prompts marked 🔄 need synthesis with another source — answer them in
-[phase2-synthesis.md](notes/phase2-synthesis.md) (**S1**: what "solved" buys;
-**S4**: exact solving vs learned play), not here.
+[phase2-synthesis.md](notes/phase2-synthesis.md) (**S4**: exact solving vs
+learned play; **S5**: what "solved" buys; **S6**: may Axis 2 feed Axis 1?), not
+here.
 
 **Reading material** (extracted via `paper-study`, gitignored under
 `notes/sources/`).
@@ -511,7 +512,15 @@ extension if the paper track activates" — does this paper reopen that decision
 
 **My take.**
 
-_(você escreve, em primeira pessoa)_
+The forward-search component is divided into two distinct responsibilities. The proof-tree manager determines which positions require proof and allocates computational effort across the evolving proof tree. Individual solvers are then responsible for proving the game-theoretic value of specific positions assigned by the manager. This separation allows global proof construction to remain independent of the algorithms used to solve individual subproblems.
+
+The paper emphasizes that the proof tree is substantially smaller than the complete search tree because not every branch must be explored to the same extent. At positions where the side to move seeks to establish a win, every opponent response must be addressed to ensure that no refutation exists. Conversely, for each opponent move, it is sufficient to identify a single continuation that preserves the desired game-theoretic value. Consequently, the proof records only the evidence required to establish the theorem rather than every possible continuation of play.
+
+This resembles the minimal-tree analysis of Knuth and Moore discussed by Russell and Norvig, but the two concepts are not identical. The minimal tree is a theoretical lower bound on the amount of search required by alpha-beta under perfect move ordering. It characterizes search complexity independently of any particular proof representation. The proof tree, by contrast, is the explicit mathematical object certifying the result. Although both exploit the asymmetry between existential ("there exists a winning move") and universal ("every opponent move must be answered") reasoning, the proof tree serves as a correctness certificate rather than merely a complexity bound.
+
+The architecture also relates naturally to Proof-Number Search (PNS). Like PNS, the proof-tree manager attempts to direct computational effort toward unresolved parts of the proof rather than expanding the game tree uniformly. However, the paper does not describe the manager as implementing PNS, nor does it rely on proof and disproof numbers as its central mechanism.
+
+For ADR-004, this paper provides additional motivation to reconsider the earlier decision to postpone proof-oriented search methods. The central role of explicit proof construction suggests that proof-directed search deserves architectural consideration. Nevertheless, the paper alone does not justify replacing alpha-beta with PNS. Instead, it supports viewing proof-oriented search as a potentially valuable extension whose benefits should be evaluated separately from the core meet-in-the-middle architecture.
 
 **Refined write-up.**
 
@@ -527,15 +536,13 @@ it a single undifferentiated enumeration pass?
 
 **My take.**
 
-The forward-search component is divided into two distinct responsibilities. The proof-tree manager determines which positions require proof and allocates computational effort across the evolving proof tree. Individual solvers are then responsible for proving the game-theoretic value of specific positions assigned by the manager. This separation allows global proof construction to remain independent of the algorithms used to solve individual subproblems.
+The paper separates proof construction from proof execution. While individual solvers establish the game-theoretic values of selected positions, the proof-tree manager is responsible for deciding where computational effort should be invested. This introduces a scheduling problem: computational resources should be directed toward the unresolved parts of the proof rather than being distributed uniformly.
 
-The paper emphasizes that the proof tree is substantially smaller than the complete search tree because not every branch must be explored to the same extent. At positions where the side to move seeks to establish a win, every opponent response must be addressed to ensure that no refutation exists. Conversely, for each opponent move, it is sufficient to identify a single continuation that preserves the desired game-theoretic value. Consequently, the proof records only the evidence required to establish the theorem rather than every possible continuation of play.
+The paper notes that the proof-tree manager may spend unnecessary effort searching for an alternative proof even though a sufficient proof already exists elsewhere in the tree. This is not a correctness issue but an efficiency issue. Because the manager does not initially know which branch will ultimately provide the shortest or easiest proof, some computational effort is inevitably spent exploring branches whose results later become unnecessary.
 
-This resembles the minimal-tree analysis of Knuth and Moore discussed by Russell and Norvig, but the two concepts are not identical. The minimal tree is a theoretical lower bound on the amount of search required by alpha-beta under perfect move ordering. It characterizes search complexity independently of any particular proof representation. The proof tree, by contrast, is the explicit mathematical object certifying the result. Although both exploit the asymmetry between existential ("there exists a winning move") and universal ("every opponent move must be answered") reasoning, the proof tree serves as a correctness certificate rather than merely a complexity bound.
+The underlying challenge is therefore one of scheduling rather than search. The objective is not simply to prove positions, but to allocate computation so that the overall proof is completed with minimal total work. Better scheduling reduces duplicated effort and concentrates resources on branches that are most likely to contribute directly to the final proof.
 
-The architecture also relates naturally to Proof-Number Search (PNS). Like PNS, the proof-tree manager attempts to direct computational effort toward unresolved parts of the proof rather than expanding the game tree uniformly. However, the paper does not describe the manager as implementing PNS, nor does it rely on proof and disproof numbers as its central mechanism.
-
-For ADR-004, this paper provides additional motivation to reconsider the earlier decision to postpone proof-oriented search methods. The central role of explicit proof construction suggests that proof-directed search deserves architectural consideration. Nevertheless, the paper alone does not justify replacing alpha-beta with PNS. Instead, it supports viewing proof-oriented search as a potentially valuable extension whose benefits should be evaluated separately from the core meet-in-the-middle architecture.
+For FLIPHEX, the situation depends on the solver architecture. A pure retrograde enumeration for the complete 4×4 state space has essentially no analogous scheduling problem: every reachable position must eventually be processed exactly once, making the computation largely a uniform enumeration task. However, if the 4×4 solver adopts the same meet-in-the-middle architecture proposed in ADR-004, the forward-search component inherits an analogous scheduling problem. Whenever multiple proof frontiers are available, the solver must decide which positions to expand first, and poor choices may waste computation proving branches that ultimately play no role in establishing the value of the initial position.
 
 **Refined write-up.**
 
@@ -864,7 +871,7 @@ Revised one-liners:
 **Prompt.** The Conclusion reflects on the scientific significance — note the
 framing (AI + parallel computing, the bioinformatics transfer, the DEEP BLUE
 comparison). What do the authors claim solving a game *buys*, beyond the game?
-This is synthesis **S1** — put the cross-source argument there (Allis's "which
+This is synthesis **S5** — put the cross-source argument there (Allis's "which
 games will survive", R&N §6.7's four limitations, and this) and here only record
 the one-line answer for FLIPHEX: what does an exact 4×4 verdict buy the project
 that a strong learned agent does not?

--- a/notes/silver-2017-alphago-zero.md
+++ b/notes/silver-2017-alphago-zero.md
@@ -1,0 +1,590 @@
+# Reading companion — Silver et al. 2017, AlphaGo Zero
+
+**Citation.** Silver, D., Schrittwieser, J., Simonyan, K., Antonoglou, I.,
+Huang, A., Guez, A., et al. (2017). *Mastering the game of Go without human
+knowledge.* **Nature** 550, 354–359. doi:10.1038/nature24270. Read from the
+UCL open-access accepted manuscript (`refs/silver-2017-alphago-zero.pdf`).
+
+**Why this source, and where it sits.** This is the *foundational* paper for
+Axis 2 — the first system to reach superhuman Go by self-play alone, with **one
+network** `f_θ(s) = (p, v)` guiding MCTS and trained on MCTS's own improved
+policy. Read it **before** Silver 2018 (which generalises the same recipe and
+*removes* pieces of it — the evaluator gate, the symmetry augmentation), and
+ideally after R&N Ch.5 (MCTS/minimax vocabulary). Everything FLIPHEX's Phase 4
+pipeline does is a scaled-down version of what is described here.
+
+**Cross-refs this reading feeds:**
+- [adr-005](docs/adr/adr-005-alphazero-scope-and-network.md) — network + the
+  factored (cell × tile × rotation) policy head (R5, the least-evidenced Phase 0
+  decision). This paper is the primary evidence for/against it.
+- [adr-003](docs/adr/adr-003-piece-representation.md) — placed tiles are inert;
+  bears on what the input tensor must (not) encode.
+- [board-geometry.md](docs/board-geometry.md) — FLIPHEX has a **trivial symmetry
+  group**; AlphaGo Zero leans on Go's 8-fold dihedral symmetry. Direct conflict,
+  see §8.
+- [exercises/ex04_alphazero_math.md](exercises/ex04_alphazero_math.md) — the loss
+  and PUCT derivations land here.
+- [notes/phase2-alphazero-paper-notes.md](notes/phase2-alphazero-paper-notes.md)
+  — the phase note; this companion is the detailed instrument behind it.
+- TIL #5 ("AlphaZero in 500 lines") — one-liner insights get parked for it.
+
+**Legend.** Prompts marked 🔄 need synthesis with another source — answer them
+in [notes/phase2-synthesis.md](notes/phase2-synthesis.md), not here.
+
+**Reading material** (extracted via `paper-study`, gitignored under
+`notes/sources/`): [manifest](sources/silver-2017-alphago-zero/manifest.json) ·
+[§2 text](sources/silver-2017-alphago-zero/sections/02-1-reinforcement-learning-in-alphago-zero.md)
++ [Nível-1 companion](sources/silver-2017-alphago-zero/study/02-reinforcement-learning.md) ·
+[§11 Methods](sources/silver-2017-alphago-zero/sections/11-methods.md)
++ [Nível-1 companion](sources/silver-2017-alphago-zero/study/11-methods.md).
+Note: Equation 1 (the loss) and Figures 1–2 are images and did not extract — the
+loss is transcribed in the §2 companion.
+
+---
+
+## §1 — The core idea: tabula rasa self-play
+
+### 1.1 — What "without human knowledge" actually means
+**Prompt.** List precisely what AlphaGo Zero removes versus prior AlphaGo (human
+games, handcrafted features, rollout policy). What *domain knowledge* do the
+authors admit they keep (rules, board symmetry, Tromp-Taylor scoring)? For
+FLIPHEX, which of those retained items has an analogue and which does not?
+
+**My take.**
+
+AlphaGo Zero represents a shift in philosophy rather than only a simplification of the architecture. Instead of relying on expert demonstrations and multiple independently trained components, the system learns entirely through self-play, starting from a randomly initialized neural network. Strategic knowledge is not transferred from human experts but emerges through reinforcement learning guided by Monte Carlo Tree Search (MCTS).
+
+Compared with previous AlphaGo systems, AlphaGo Zero removes three major sources of human expertise:
+
+- **Human expert games:** no supervised pre-training from professional Go games. All training data is generated through self-play.
+- **Handcrafted features:** the input consists only of the raw board state and player information, without manually engineered tactical features.
+- **Rollout policy:** leaf evaluation no longer depends on fast rollout simulations. Instead, a single neural network estimates both the policy and the value of a position.
+
+The authors nevertheless retain several forms of domain knowledge. The game rules are provided explicitly so that legal moves and game outcomes can be computed. The implementation also exploits Go's eight-fold board symmetry as a data augmentation technique and uses Tromp-Taylor scoring to determine game results. Therefore, "without human knowledge" should be interpreted as removing human strategic expertise rather than eliminating all domain-specific assumptions.
+
+For FLIPHEX, some of these retained elements have direct analogues. The game rules and legal move generation are intrinsic components of the environment, just as they are in Go. However, board symmetry differs substantially. Whereas Go benefits from an eight-fold dihedral symmetry that can be exploited during training, FLIPHEX has only trivial symmetry, making the augmentation strategy used by AlphaGo Zero largely inapplicable.
+
+**Refined write-up.**
+
+Accurate — this is the right reading. Two sharpenings. First, the paper's own
+list of *retained* domain knowledge is four items, not two: (1) the rules, for
+legal-move and terminal detection; (2) Tromp–Taylor scoring; (3) the 8 board
+symmetries, used both to augment data and to average evaluations; (4) the input
+is the current position *plus a short stone-history*. It removes: human games,
+handcrafted features, rollouts, and the *separate* policy/value networks (now
+fused). Second — and this transfers cleanly to FLIPHEX — Go under its komi is a
+**two-outcome** game (win/loss, no draw), which is why the value target is ±1.
+FLIPHEX shares exactly this (25 cells, odd → draws impossible), so the ±1 value
+head carries over unchanged. Of the retained items, FLIPHEX has: rules ✓ (the
+engine), scoring ✓ (count colours). It does **not** have Go's symmetry — the one
+structural gift AlphaGo Zero leans on that we cannot inherit (developed in §8.1).
+
+### 1.2 — One network, two heads
+**Prompt.** Write the signature `f_θ(s) = (p, v)` exactly: what is `p`, what is
+`v`, what is the range of `v` and why `tanh`? This is the shape adr-005 commits
+FLIPHEX to — does the paper give `p` as a flat distribution over moves?
+
+**My take.**
+
+AlphaGo Zero represents its neural network as `f_θ(s) = (p, v)`, where `s` is the current game state. The network jointly predicts:
+
+- `p`: a probability distribution over the legal moves from state `s`, used as the prior policy that guides Monte Carlo Tree Search (MCTS).
+- `v`: a scalar estimate of the expected game outcome from the perspective of the current player.
+
+The value prediction is constrained to the interval `[-1, 1]`, matching the game outcomes (`-1` = loss, `0` = draw, `+1` = win). The value head therefore uses a `tanh` activation, whose output naturally lies in this range.
+
+The paper defines `p` simply as a probability distribution over legal moves. It does not propose a factored or hierarchical policy representation. Consequently, FLIPHEX's factored policy head (cell × tile × rotation) is an architectural adaptation rather than a design prescribed by AlphaGo Zero.
+
+**Refined write-up.**
+
+Right on the shape and on the R5 verdict. Two precisions. (a) The target `z` is
+in `{-1, +1}` (no draw in Go, and none in FLIPHEX); the *prediction* `v` is
+continuous in `(-1, 1)` via `tanh`, read as an expected outcome ≈ `2·P(win) − 1`.
+So drop the "0 = draw" case entirely — its absence is actually a point in favour
+of reusing the value head unchanged. (b) `p` is defined over **all** moves
+(19×19 + pass = 362 for Go), then illegal moves are masked out and the rest
+renormalised — it is not a distribution over legal moves *a priori*. That masking
+step is exactly what FLIPHEX's factored head will also do, over illegal
+(cell, tile, rotation) triples. Net for [adr-005](docs/adr/adr-005-alphazero-scope-and-network.md):
+the paper fixes `(p, v)` and the `tanh` value, and says **nothing** about
+factoring `p` — the factorisation is ours to justify and test (R5).
+
+---
+
+## §2 — Reinforcement learning in AlphaGo Zero (the algorithm)
+
+### 2.1 — MCTS as a policy-improvement operator
+**Prompt.** The headline mechanism: the search produces a policy `π` (from visit
+counts) *stronger* than the network's raw `p`, and the network is trained toward
+`π`. State why this is a policy-improvement step. This is the single most
+important idea in the paper — predict, before reading the proof sketch, why
+searching then imitating the search beats imitating the network directly.
+
+**My take.**
+
+The neural network provides an initial policy `p`, but this prediction is only an estimate based on the current network parameters. MCTS refines this estimate by exploring many continuations of the game, combining the network's prior policy with search statistics. As a result, the search may discover that moves initially assigned low probability perform better than expected, while apparently promising moves prove weaker after deeper analysis.
+
+The improved policy `π`, obtained from the MCTS visit counts, therefore represents a stronger decision than the network's raw prediction. Training the network to imitate `π` is a policy-improvement step because the learning target is generated after a more informed search rather than by the network itself. Over successive self-play iterations, the network learns to approximate the decisions it would reach after search, making both the network and the search progressively stronger.
+
+**Refined write-up.**
+
+Well captured — this is the heart of the paper. The formal name is worth fixing
+in your head: it is **approximate policy iteration** (Sutton & Barto framing).
+MCTS is the *policy-improvement* operator (it returns `π` provably no worse, and
+usually much better, than the prior `p`), and playing the game to a terminal `z`
+is the *policy-evaluation* operator; the algorithm just alternates the two. The
+precise reason "search then imitate" beats "imitate `p`": the tree does bounded
+lookahead and evaluates its leaves with the **same network's value head**, so `π`
+aggregates many `v`-estimates into a single, lower-variance, deeper-informed
+target than the raw prior could ever be. This is [ex04](exercises/ex04_alphazero_math.md)
+Q2 (why `π` is the stronger target) and a strong TIL #5 seed.
+
+### 2.2 — The loss function
+**Prompt.** Copy the loss `l = (z − v)² − πᵀ log p + c‖θ‖²`. Identify each term
+(value regression, policy cross-entropy, L2). What is `z`, and how is it labelled
+for every position in a self-play game? Draft the term-by-term interpretation
+here; it becomes ex04 Q1.
+
+**My take.**
+
+AlphaGo Zero optimizes the following loss function:
+
+`l = (z − v)² − πᵀ log p + c‖θ‖²`
+
+Each term has a distinct purpose:
+
+- **`(z − v)²` — Value regression.** This mean squared error trains the value head to predict the final game outcome. The target `z` is the actual result of the self-play game from the perspective of the player to move at state `s` (`-1` = loss, `0` = draw, `+1` = win).
+
+- **`−πᵀ log p` — Policy cross-entropy.** This term trains the policy head to match the improved policy `π` produced by MCTS rather than the network's raw prediction. In this way, the network learns to approximate the stronger decisions obtained through search.
+
+- **`c‖θ‖²` — L2 regularization.** This penalty discourages excessively large network weights, helping reduce overfitting and improving generalization.
+
+The game outcome `z` is assigned to every position encountered during a self-play game. Thus, every state visited in a game becomes a supervised training example with target `(π, z)`: the improved policy from search and the final game result.
+
+**Refined write-up.**
+
+Correct on all three terms. Precisions: the cross-entropy `−πᵀ log p` uses the
+**soft** distribution `π` (visit-count proportions), not a one-hot label — that
+is what makes it *distillation of the search*, not classification. `z_t = ±r_T`
+with the sign taken from the player to move at step `t` (you said this — good).
+Note there is **no entropy bonus** in the loss; all exploration comes from MCTS
+and the root Dirichlet noise (§6.3), not from the objective. For FLIPHEX the loss
+is usable verbatim, with `z ∈ {-1, +1}`. This is [ex04](exercises/ex04_alphazero_math.md)
+Q1 — transcribe your term-by-term breakdown there.
+
+### 2.3 — The self-play → train loop
+**Prompt.** Sketch the loop: self-play generates `(s, π, z)` triples → network
+trains on them → improved network generates better self-play. Where does the
+data come from and how much is reused (replay)? How does this differ from
+classical minimax, which has no learning at all? 🔄 (with R&N Ch.5)
+
+**My take.**
+
+AlphaGo Zero follows an iterative reinforcement learning loop. First, the current neural network plays games against itself using MCTS guided by its policy and value predictions. During each self-play game, every visited state is stored together with the improved search policy `π` and, once the game ends, the final outcome `z`. This produces training examples of the form `(s, π, z)`.
+
+The collected self-play data are stored in a replay buffer, from which mini-batches are sampled to train the neural network. As the network improves, it provides more accurate policy priors and value estimates, allowing MCTS to perform stronger searches. These stronger searches generate higher-quality training targets, creating a positive feedback loop between search and learning.
+
+Unlike classical minimax or standard MCTS, which perform search independently for each game and discard all information afterward, AlphaGo Zero accumulates knowledge across games by updating the neural network. The search is therefore not only used to select moves, but also to generate training data that continually improves future searches.
+
+**Refined write-up.**
+
+Good. One concrete detail for our Phase-4 buffer sizing: AlphaGo Zero samples
+each mini-batch **uniformly from the most recent ~500,000 self-play games** — a
+sliding window, not an unbounded replay of all history. That bounded window is
+what keeps the data on-policy enough to be a valid evaluation target.
+Reminder: this prompt is 🔄 — its cross-source half (contrast with minimax/αβ,
+which are search-only and stateless across games, learning nothing) belongs in
+[phase2-synthesis.md](notes/phase2-synthesis.md) **S1**. Move that half there
+when you read R&N Ch.5; the crisp one-liner is *"classical search recomputes;
+AlphaZero's search compounds, because its output trains the prior."*
+
+---
+
+## §3 — Empirical analysis of training
+
+### 3.1 — The learning curve and its rigor
+**Prompt.** What is the x-axis and the Elo y-axis of the main training-curve
+figure? Over what wall-clock/how many games? Is there any variance band or
+single-run reporting — what would a statistician want that the paper does not
+show? (Relevant to H3: our own convergence-across-seeds claim.)
+
+**My take.**
+
+The main training curve reports the strength of AlphaGo Zero as training progresses. The x-axis represents training time (wall-clock time, shown in days) together with the corresponding amount of self-play experience, while the y-axis reports playing strength in Elo rating. The paper shows that AlphaGo Zero reaches superhuman performance within a few days of training and continues improving over tens of millions of self-play games.
+
+From a statistical perspective, however, the experimental reporting is limited. The figure presents a single training trajectory without variance bands, confidence intervals, or results across multiple random seeds. As a result, the paper demonstrates that the method can converge, but it does not quantify the variability or reproducibility of the learning process.
+
+This observation is particularly relevant for FLIPHEX. If our project claims convergence or learning stability (H3), reporting results across multiple random seeds and summarizing their variability would provide stronger empirical evidence than a single training curve.
+
+**Refined write-up.**
+
+Exactly the H3 point, and correctly identified as a *presentation* weakness we
+can beat. Concrete numbers to anchor it: the headline 3-day run used a 20-block
+network and **4.9M** self-play games; the later 40-day, 40-block run used ~**29M**
+and reaches the top Elo. x-axis = training steps/days, y = Elo. Your statistician's
+objection stands: one trajectory, no seed variance, no confidence band. Our H3
+does the opposite by design (≥5 seeds, Wilson/bootstrap bands per the roadmap's
+Phase 5) — so "the paper shows it *can* converge; we show *how reliably*" is a
+real, defensible contribution over the source, not just a critique.
+
+### 3.2 — Beating the supervised-learning baseline
+**Prompt.** AGZ (pure RL) is compared against a network trained on human games.
+Which wins, and what does the crossover tell you about whether human priors help
+or hurt? What is the FLIPHEX analogue (we have *no* human games at all)?
+
+**My take.**
+
+AlphaGo Zero ultimately outperforms the supervised-learning baseline trained on human expert games. Although the supervised model begins with stronger prior knowledge, its performance eventually plateaus because it is constrained by the strategies present in the human training data. In contrast, AlphaGo Zero starts without strategic knowledge but continues to improve through self-play, eventually surpassing the human-trained network.
+
+The crossover between the two learning curves suggests that human priors are beneficial for accelerating initial learning, but they are not necessary to achieve the highest level of performance. By relying solely on reinforcement learning, AlphaGo Zero is free to discover strategies that extend beyond established human play.
+
+For FLIPHEX, there is no supervised-learning baseline because no expert game database exists. This makes self-play not only an attractive alternative but the natural training paradigm. Rather than reproducing human strategies, the objective is to allow strong strategies to emerge directly from interaction with the game environment.
+
+**Refined write-up.**
+
+Correct. Sharpen the lesson: the supervised network learned faster *and* was
+initially stronger, but **plateaued** — because it is capped by the ceiling of
+the human games it imitated. Pure RL starts weaker and keeps climbing past that
+ceiling. So the takeaway is not "human priors hurt" but "human priors cap you at
+the data's quality." The FLIPHEX case is even cleaner than Go's: no human corpus
+exists at all, so self-play is not a *choice over* supervised learning — it is
+the only route, and there is no inherited ceiling to escape. That is a genuine
+point in favour of Axis 2 for this game (relevant to H1/H3).
+
+---
+
+## §4 — Knowledge learned by AlphaGo Zero
+
+### 4.1 — Rediscovery vs novelty
+**Prompt.** The paper claims AGZ rediscovered known joseki and then discarded
+some for novel play. What is the evidence, and how would you design the FLIPHEX
+analogue — detecting whether the agent finds openings the designers did not
+anticipate? (Ties to H5, archetype usage.)
+
+**My take.**
+
+The authors report that AlphaGo Zero initially rediscovered well-established joseki despite receiving no human demonstrations during training. As learning progressed, however, it increasingly deviated from conventional human opening theory and adopted novel sequences that were later recognized as strong by expert players. This serves as qualitative evidence that self-play can first recover known strategic principles and then move beyond them.
+
+The evidence is primarily observational rather than statistical. The paper compares representative opening sequences and discusses expert analyses of AlphaGo Zero's games, but it does not define a quantitative metric for measuring strategic novelty.
+
+For FLIPHEX, an analogous evaluation would be to analyze whether the trained agent consistently develops opening patterns or strategic archetypes that were not anticipated by the game's designers. Such an analysis could compare opening frequencies, board-control patterns, or archetype usage across training, helping determine whether the agent merely converges to expected play or discovers genuinely novel strategies. This directly supports H5 by measuring the emergence and diversity of strategic archetypes rather than only final playing strength.
+
+**Refined write-up.**
+
+Accurate, and the H5 operationalisation is the valuable part. The paper's novelty
+evidence is purely **qualitative** (expert commentary, joseki-over-time vignettes)
+— no novelty metric, as you note. FLIPHEX can do strictly better because the deck
+*is* a finite, labelled vocabulary: track (i) per-archetype placement frequency
+and (ii) win-correlation across training, plus (iii) opening-move entropy over
+time. That turns "did it find openings the designers didn't expect?" into three
+measurable curves — which is exactly the H5 test named in the roadmap. Worth a
+line in the H5 statement when you lock hypotheses.
+
+---
+
+## §5 — Methods: neural network architecture
+
+### 5.1 — The residual tower and the two heads
+**Prompt.** Describe the body (conv → residual blocks) and the two heads. How is
+the **policy head** shaped for Go (19×19 + 1 pass)? This is *flat*. adr-005
+chose a **factored** head for FLIPHEX (cell × tile × rotation). Does AGZ offer
+any evidence that a flat head over the full action set is fine at this scale, or
+is Go's action space just small enough that the question never arises? Record
+the honest verdict for R5.
+
+**My take.**
+
+AlphaGo Zero employs a deep convolutional neural network composed of an initial convolutional layer followed by a tower of residual blocks. This shared feature extractor feeds two output heads: a policy head, which predicts move probabilities, and a value head, which estimates the expected game outcome.
+
+For Go, the policy head is represented as a flat probability distribution over all legal actions. On a 19×19 board, this corresponds to one output for each board intersection plus an additional output for the pass move, yielding a single flat action distribution.
+
+The paper does not investigate alternative policy parameterizations. It neither compares flat and factored policy heads nor discusses whether the action space size influenced this architectural choice. Therefore, AlphaGo Zero provides evidence that a flat policy head is sufficient for Go, but it does not establish that this representation is optimal or generally applicable to games with more structured action spaces.
+
+For ADR-005 (R5), the honest conclusion is that the paper supports learning a policy over actions but provides no direct evidence for or against a factored policy representation. The decision to factor the FLIPHEX policy into (cell × tile × rotation) is therefore an architectural adaptation motivated by the structure of the game's action space rather than by empirical evidence from AlphaGo Zero.
+
+**Refined write-up.**
+
+Correct, and the R5 verdict is the honest one. Concrete architecture, to make it
+tangible: body = one conv block + **19 (or 39) residual blocks** of 256 filters;
+**policy head** = 1×1 conv → fully-connected → 362 logits (flat); **value head**
+= 1×1 conv → FC(256) → scalar `tanh`. So "flat head" literally means one dense
+layer over the whole action set. Go's 362 actions are small enough that factoring
+never *needs* to arise. FLIPHEX's raw action set is larger (≈1,450 on ply 1) but
+still not huge, so adr-005's factoring is an **efficiency / generalisation bet**,
+not a necessity — and, as you conclude, unsupported either way by this paper.
+That is precisely why adr-005 flags it as R5 *to be tested empirically in
+Phase 4*, e.g. flat-vs-factored head as an ablation.
+
+### 5.2 — The input tensor
+**Prompt.** AGZ stacks 17 binary planes: 8 of own-stone history, 8 of opponent
+history, 1 for colour to play. *Why history planes* (ko, repetition)? FLIPHEX is
+fully observable and — adr-003 — **placed tiles are inert with no stored
+rotation**. Argue whether FLIPHEX needs any history planes at all, and list the
+planes you would actually use (own / opp / empty / joker / hand bitmasks).
+
+**My take.**
+
+AlphaGo Zero represents each board state as a stack of 17 binary feature planes: eight planes encoding the recent history of the current player's stones, eight planes for the opponent's stones, and one plane indicating which player is to move. The history planes are included because the legality and strategic interpretation of some moves depend on previous board states, particularly due to the ko rule, which prevents immediate repetition of positions.
+
+FLIPHEX differs fundamentally in this regard. According to ADR-003, the game is fully observable, placed tiles become inert, and their rotations are not stored after placement. Assuming no game rule depends on previous board configurations, the current state is sufficient to determine all legal actions and future transitions. Therefore, history planes appear unnecessary.
+
+Instead, the input tensor should encode only the current game state. A suitable representation could include separate planes for the current player's tiles, the opponent's tiles, empty cells, joker locations (if represented on the board), and additional binary feature planes describing the tiles currently available in each player's hand. This representation preserves the Markov property while providing all information required for decision making.
+
+**Refined write-up.**
+
+The Markov argument is right, and it hangs directly on
+[adr-003](docs/adr/adr-003-piece-representation.md): FLIPHEX is Markov in
+`(colours, hands, to_move)` *precisely because placed tiles are inert* — there is
+no ko, no repetition rule, and no hidden information, so **zero history planes**
+are needed (Go needs them only for ko/superko). One correction to your plane
+list: the **joker needs no board plane.** Once placed it is just an inert,
+coloured token that scores by colour like any other tile — its identity never
+affects future dynamics or scoring. It only needs representation as a distinct
+*playable tile in hand* (a hand bit for Player 1), because it is a legal
+zero-arrow action. So the encoding simplifies to: own-colour, opponent-colour,
+empty, per-player hand bitmask planes, and a to-move scalar — no per-tile
+rotation, no history, no joker-location plane. That simplification is a nice,
+recordable consequence of adr-003.
+
+---
+
+## §6 — Methods: MCTS (the PUCT search)
+
+### 6.1 — The four phases and the PUCT rule
+**Prompt.** Write the select/expand+evaluate/backup cycle and the selection
+formula
+`a* = argmax_a [ Q(s,a) + c_puct · P(s,a) · √(Σ_b N(s,b)) / (1 + N(s,a)) ]`.
+Label exploitation / prior / exploration. How does `P(s,a)` (network prior) enter
+expansion? This becomes ex04 and TIL #2.
+
+**My take.**
+
+Each MCTS simulation consists of four phases:
+
+1. **Selection:** Starting from the root, repeatedly choose the action that maximizes
+
+\[
+a^* = \arg\max_a \left[
+Q(s,a)
++
+c_{\text{puct}}
+P(s,a)
+\frac{\sqrt{\sum_b N(s,b)}}{1+N(s,a)}
+\right].
+\]
+
+2. **Expansion and evaluation:** When a leaf node is reached, it is expanded. The neural network evaluates the state, producing a policy prior \(P(s,\cdot)\) over legal actions and a value estimate \(v\). The prior initializes the outgoing edges of the new node and biases future exploration toward actions the network considers promising.
+
+3. **Backup:** The predicted value is propagated back through every edge visited during the simulation, updating the action-value estimates \(Q(s,a)\) and visit counts \(N(s,a)\).
+
+After many simulations, the action with the highest visit count is selected.
+
+In the PUCT equation, the two terms have distinct roles. The value estimate \(Q(s,a)\) represents **exploitation**, favoring actions that have performed well during previous simulations. The exploration term combines the network prior \(P(s,a)\), the exploration constant \(c_{\text{puct}}\), and the visit counts. The prior biases exploration toward actions that the neural network predicts to be promising, while the visit-count ratio gradually shifts search effort toward less explored actions.
+
+Unlike classical UCT, where all unexplored actions are initially treated equally, PUCT injects learned knowledge directly into the search through the policy prior, allowing the search to focus on more promising branches from the very beginning.
+
+**Refined write-up.**
+
+Correct — phases and term-roles all right. Small precisions: a freshly expanded
+node's edges initialise `N = 0`, `Q = 0`, `P = ` network prior; selection
+maximises `Q + U` at every level down to a leaf; the value backed up is the
+leaf's network `v`, sign-flipped per level for the alternating player. And you
+nailed the easy-to-miss point — the move actually played from the root is
+`argmax N` (robustness), **not** `argmax Q`. This is [ex04](exercises/ex04_alphazero_math.md)
+Q5 and the core of TIL #2. The UCT→PUCT contrast is also 🔄 **S1** in the
+synthesis (UCB1's `√(ln N / n)` exploration vs PUCT's prior-weighted
+`P·√ΣN/(1+N)`).
+
+### 6.2 — No rollouts
+**Prompt.** Classic MCTS ends a simulation with a random rollout; AGZ replaces it
+with the value head `v`. Why is that both faster and stronger, and why does a
+*perfect-information* game make the value estimate trustworthy in a way an
+imperfect-information game (your PTCG) would not? 🔄 (with R&N Ch.5)
+
+**My take.**
+
+Traditional MCTS estimates the value of a leaf node by performing a random rollout until the end of the game. AlphaGo Zero replaces this expensive simulation with the neural network's value prediction \(v\), which directly estimates the expected outcome from the current position. This makes search substantially faster because each simulation avoids playing dozens or hundreds of additional random moves. It is also stronger because the learned value function provides a much more informed estimate than a random rollout, whose outcome is often noisy and unrealistic.
+
+This approach works particularly well in Go because it is a perfect-information game. The complete game state is fully observable, so the value network receives all information needed to estimate the probability of winning from that position. As training progresses, the network learns an increasingly accurate mapping from board states to expected outcomes.
+
+In an imperfect-information game such as Pokémon TCG, the same observed game state may correspond to many different hidden states due to unknown cards in the opponent's hand, deck, or prize cards. Consequently, the value network must estimate an expectation over hidden information rather than over a fully observed state, making accurate value prediction significantly more difficult. This is one reason why directly applying AlphaGo Zero's search algorithm to imperfect-information games is considerably more challenging.
+
+**Refined write-up.**
+
+Correct, and the perfect-information point is the one that matters. Sharpen it: a
+random rollout is a *single* Monte-Carlo sample of one arbitrary continuation —
+high-variance, often unrealistic — whereas the value head `v` is a *learned,
+low-variance* estimate of the same quantity. So swapping rollouts for `v` is both
+faster (no dozens of extra moves per simulation) and stronger (better signal per
+simulation). The perfect- vs imperfect-information split you drew is exactly the
+crux: in Go/FLIPHEX `v` is a function of the **true** state, so with training it
+can be accurate; in PTCG the same *observation* maps to many hidden states, so
+`v` would have to estimate an **expectation over an information set** — which is
+why perfect-info MCTS uses the value net directly while imperfect-info needs
+determinization / IS-MCTS. This 🔄 belongs in synthesis **S1**, and it is a clean
+**TIL #1** hook — arguably the single biggest thing FLIPHEX gains over your PTCG
+work.
+
+### 6.3 — Exploration: Dirichlet noise and temperature
+**Prompt.** At the root, AGZ adds Dirichlet noise to the prior; the move is
+sampled with temperature `τ = 1` for the first 30 moves then `τ → 0`. Why noise
+*only* at the root? For FLIPHEX (25 plies total), what "first 30 moves" scales
+to, and how the τ schedule interacts with our short game.
+
+**My take.**
+
+AlphaGo Zero injects Dirichlet noise only into the root node's prior probabilities before each MCTS search. This encourages different self-play games to explore alternative opening moves while leaving the remainder of the search tree guided by the learned policy and accumulated search statistics. If noise were added throughout the tree, every simulation would become unnecessarily noisy, reducing the effectiveness of MCTS rather than simply encouraging exploration.
+
+Action selection also depends on the temperature parameter \( \tau \). During the first 30 moves, actions are sampled according to the MCTS visit counts (\( \tau = 1 \)), promoting exploration and generating diverse self-play data. After move 30, the temperature is effectively reduced to zero, so the move with the highest visit count is selected almost deterministically, emphasizing strong play over exploration.
+
+This schedule does not transfer directly to FLIPHEX because games are much shorter (approximately 25 plies). Keeping a high temperature for the first 30 plies would mean exploring throughout the entire game. A more appropriate strategy is to scale the exploration period to the game's length, using a positive temperature only during the opening portion before switching to deterministic action selection for the remainder of the game. The exact cutoff should be treated as a tunable hyperparameter rather than copied directly from AlphaGo Zero.
+
+**Refined write-up.**
+
+Correct, and well reasoned — you got both the "why root-only" and the FLIPHEX
+scaling right. Three precisions worth banking. (1) The exact noise mix is
+`P(s,a) = (1−ε)·p_a + ε·η_a` with `η ~ Dir(0.03)` and `ε = 0.25` — so a full
+**quarter** of the root prior mass is replaced by noise, which is a lot.
+(2) **Do not copy `α = 0.03`.** That value is tuned to Go's ~250 legal moves; the
+Dirichlet concentration is scaled to the branching factor (fewer legal moves →
+larger α). FLIPHEX has far fewer moves per ply, so its α must be re-tuned — a
+wrong α here silently either floods the search with noise or fails to explore.
+(3) A sharper reason for root-only: noise at *internal* nodes would corrupt the
+very `Q`/value estimates MCTS is trying to compute, degrading the search; the
+root is the one place we *want* an exploratory visit distribution, because that
+distribution becomes the training target `π`. Your temperature point stands:
+`τ = 1` ⇒ sample ∝ `N`, `τ → 0` ⇒ argmax `N`; "first 30 moves" is ~12% of a
+~250-move Go game, so proportionally ~3 plies of FLIPHEX — but treat the opening
+cutoff (say the first 6–10 plies) as a tunable hyperparameter, exactly as you
+said. Good material for [ex04](exercises/ex04_alphazero_math.md) Q5 and TIL #2.
+
+---
+
+## §7 — Methods: self-play pipeline and optimisation
+
+### 7.1 — The evaluator gate
+**Prompt.** AGZ only promotes a new network to generate self-play if it beats the
+current best in ≥ 55% of games. State the mechanism. Note for §8: Silver 2018
+*removes* this gate — flag the disagreement now and resolve it there. 🔄
+Does a laptop-scale FLIPHEX run need the gate, or is it complexity we can drop?
+
+**My take.**
+
+After each training iteration, AlphaGo Zero evaluates the newly trained neural network against the current best network. The candidate is promoted only if it wins at least 55% of the evaluation games; otherwise, the previous best model continues generating self-play data. This mechanism acts as a quality-control gate, preventing weaker networks from degrading the training process through poor self-play games.
+
+It is important to note that this design changes in AlphaZero (Silver et al., 2018), where the evaluation gate is removed. The reason for this change should be discussed when comparing the two papers.
+
+For a laptop-scale implementation such as FLIPHEX, the evaluation gate is probably unnecessary. Running evaluation matches after every training iteration increases computational cost and implementation complexity. Since training occurs sequentially on a single machine rather than on a large distributed system, simply continuing from the latest checkpoint is a reasonable engineering choice. If training later proves unstable, the gate can be introduced as an optional safeguard rather than as a mandatory component.
+
+**Refined write-up.**
+
+Correct. Concrete detail: the gate runs a **400-game** evaluation match and
+promotes the candidate only on **> 55%** — a threshold set high enough to filter
+noise, not just any edge. Its purpose is to guarantee that self-play data always
+comes from the strongest network so far, so a single bad gradient update cannot
+poison the data stream. Flag for §8 / synthesis **S2**: AlphaZero (2018) *drops*
+this gate and trains one continuously-updated network — resolve *why* there. Your
+laptop-scale reasoning is sound: skip the gate initially, keep it as an optional
+safeguard if training proves unstable.
+
+### 7.2 — Compute and simulation budget
+**Prompt.** Extract the concrete numbers: MCTS simulations per move (~1600),
+games generated, hardware (TPUs), training days. Then estimate the *ratio* to
+FLIPHEX: ~1450 legal first-ply moves, 25-ply games, a single laptop GPU. What
+sim-count per move is plausible for us, and does adr-005's "compact network"
+assumption survive this comparison?
+
+**My take.**
+
+AlphaGo Zero performs approximately 1,600 MCTS simulations per move, generates millions of self-play games, trains for several days on large TPU clusters, and relies on computational resources that are far beyond what is available on consumer hardware. These numbers demonstrate that the reported performance depends not only on the learning algorithm but also on an enormous search budget.
+
+FLIPHEX operates under very different constraints. Although its opening branching factor is large (approximately 1,450 legal first-ply actions), games are much shorter (around 25 plies instead of hundreds of moves in Go), and training is intended to run on a single laptop GPU. Under these conditions, performing 1,600 simulations per move would likely be impractical.
+
+A search budget on the order of tens to a few hundred simulations per move appears substantially more realistic for a laptop-scale implementation. The exact value should be selected empirically by balancing playing strength against training time.
+
+This comparison also supports ADR-005's decision to use a compact neural network. With a limited simulation budget, network evaluation becomes the dominant computational cost inside MCTS. A smaller network reduces inference latency, allowing more simulations within the same compute budget. Thus, the compact-network assumption is strengthened rather than weakened by the hardware constraints of the project.
+
+**Refined write-up.**
+
+Correct on every count, and your closing insight is the subtle one — worth
+affirming strongly. Exact anchors to cite: **1,600 simulations/move** (~0.4 s
+each), **25,000 self-play games per iteration**, training sampled from the most
+recent **500,000** games; hardware is **4 TPUs** for the player plus 64 GPUs and
+19 CPUs for optimisation; the two runs are **20-block / 3-day (4.9M games)** and
+**40-block / 40-day (~29M games)**. The point you reached at the end is exactly
+right and often missed: under a *small* simulation budget the per-node network
+evaluation dominates MCTS cost, so a **compact network is strengthened, not
+weakened** — a smaller net means lower inference latency means more simulations
+per unit of compute. adr-005's compact-network bet survives cleanly. Two design
+levers to carry into Phase 4: batch the leaf evaluations (AGZ evaluates in
+mini-batches of 8 inside the search), and — with a net this small — CPU inference
+may actually beat GPU once you count transfer overhead. A concrete laptop
+starting point: ~**100–200 sims/move** and games in the thousands-to-tens-of-
+thousands, tuned by the strength-vs-time trade-off you named.
+
+---
+
+## §8 — Domain knowledge, symmetry, and limitations
+
+### 8.1 — Symmetry augmentation (the conflict to flag)
+**Prompt.** AGZ exploits Go's 8-fold dihedral symmetry both to augment training
+data and to average MCTS evaluations. **FLIPHEX's board has a trivial symmetry
+group** ([board-geometry.md](docs/board-geometry.md)). State exactly what
+capability FLIPHEX therefore *loses* (free 8× data augmentation, evaluation
+averaging), and what that predicts about our sample-efficiency versus AGZ. This
+is a genuine source-vs-project conflict — record it, do not smooth it over.
+
+**My take.**
+
+AlphaGo Zero exploits the eight symmetries of the Go board (the dihedral group D₄). Every board position can be rotated or reflected to produce seven equivalent states. The paper uses these symmetries in two ways: first, to augment the training set by generating additional equivalent examples; second, to average neural network evaluations across symmetric transformations during MCTS, reducing prediction variance.
+
+FLIPHEX presents a genuine conflict with this design. According to the board geometry specification, its board has only the trivial symmetry group, meaning that non-identity rotations or reflections do not preserve the game's geometry. Consequently, neither symmetry-based data augmentation nor symmetry-based evaluation averaging can be applied.
+
+The practical implication is a reduction in sample efficiency. AlphaGo Zero effectively extracts more supervised signal from every self-play position and obtains more stable value and policy estimates through symmetry averaging. FLIPHEX loses both advantages, so achieving comparable policy quality is likely to require more self-play games or additional training iterations. This is a fundamental consequence of the game's geometry rather than an implementation choice.
+
+**Refined write-up.**
+
+Correct, and this is the load-bearing conflict of the whole reading. Quantify it
+so it bites: the 8-fold symmetry means each self-play position yields up to **8**
+training examples, and each network evaluation is averaged over 8 orientations
+(variance down by ≈ √8). FLIPHEX gets **1×** on both. Implication: to see each
+distinct position-class as often, we need on the order of several times more
+self-play games, and our per-position value/policy estimates are noisier. The
+constructive flip side — and a genuine advantage Go did *not* have — is that
+FLIPHEX has a tractable **exact solver** (Axis 1) to supply ground truth on small
+variants, partly compensating for the lost sample-efficiency (synthesis **S3/S4**).
+Record this in adr-005 as a known handicap, not a blocker.
+
+### 8.2 — The authors' acknowledged limitations
+**Prompt.** What does the paper itself concede (Go-specific choices, compute,
+generality)? Which limitation is *load-bearing* for whether the AlphaZero recipe
+transfers to a tiny original game like FLIPHEX at all?
+
+**My take.**
+
+Although AlphaGo Zero is presented as a general reinforcement learning framework, the paper acknowledges several practical limitations. The experiments are conducted exclusively on Go, they require massive computational resources, and they exploit domain-specific properties such as perfect information, deterministic dynamics, and board symmetries. Therefore, the paper demonstrates the method's effectiveness for Go rather than proving universal applicability.
+
+Among these limitations, the most load-bearing for transferring the AlphaZero recipe to FLIPHEX is not computational scale but the assumptions about the game itself. AlphaGo Zero relies on a deterministic, perfect-information environment with fully known rules, allowing self-play, MCTS, and the value network to operate on complete game states. FLIPHEX satisfies these assumptions despite being much smaller than Go.
+
+In contrast, computational scale primarily affects performance rather than correctness. A laptop implementation may converge more slowly or achieve a lower playing strength, but the learning algorithm itself remains applicable. Therefore, the strongest argument for transferring the AlphaZero methodology to FLIPHEX is that the underlying assumptions of the learning framework are preserved, even though the game's complexity and available compute differ substantially.
+
+**Refined write-up.**
+
+Correct, and a good place to close. State the transfer condition crisply: the
+recipe transfers **iff** the environment is deterministic, perfect-information,
+and cheap to simulate with known terminal + scoring rules. FLIPHEX satisfies all
+three (fast engine, exact rules, no hidden state), so — as you argue — compute,
+not applicability, is the only real risk. The single honest caveat to carry
+forward: FLIPHEX does **not** inherit Go's symmetry advantage (§8.1), so
+"transfers" does not mean "equally sample-efficient." That one asterisk is the
+thread connecting this whole reading to Phase 4.
+
+---
+
+## Lessons Learned
+
+_(filled at merge — what changed in how I think about Axis 2.)_
+
+## Failed Attempts
+
+_(filled at merge — revised assumptions, reading dead-ends.)_

--- a/notes/silver-2018-alphazero.md
+++ b/notes/silver-2018-alphazero.md
@@ -1,0 +1,335 @@
+# Reading companion — Silver et al. 2018, AlphaZero
+
+**Citation.** Silver, D., Hubert, T., Schrittwieser, J., Antonoglou, I., Lai, M.,
+Guez, A., et al. (2018). *A general reinforcement learning algorithm that masters
+chess, shogi, and Go through self-play.* **Science** 362(6419), 1140–1144.
+Read from the arXiv preprint 1712.01815 (`refs/silver-2018-alphazero.pdf`).
+
+**Why this source, and where it sits.** Read **after**
+[Silver 2017 (AlphaGo Zero)](notes/silver-2017-alphago-zero.md) — this paper is
+essentially a *diff* against it, and assumes its notation. Its importance for
+FLIPHEX is specific and large: AlphaZero generalises the AGZ recipe to **chess
+and shogi**, two games that — like FLIPHEX and unlike Go — have **no exploitable
+board symmetry**. So where AGZ treated symmetry as a free gift we cannot inherit,
+**AlphaZero is the closer template for FLIPHEX**: it shows the recipe working in
+the no-symmetry regime, with a *structured* (factored-like) policy head. Focus
+only on the deltas; do not re-derive what the AGZ note already covers.
+
+**Cross-refs this reading feeds:**
+- [adr-005](docs/adr/adr-005-alphazero-scope-and-network.md) — R5: chess/shogi
+  use a **structured** action encoding (a plane-factored policy head), the
+  closest empirical precedent for FLIPHEX's (cell × tile × rotation) factoring.
+- [board-geometry.md](docs/board-geometry.md) — FLIPHEX's trivial symmetry group;
+  AlphaZero drops symmetry augmentation entirely, matching our situation.
+- [notes/phase2-synthesis.md](notes/phase2-synthesis.md) — resolves **S2**
+  (evaluator gate removed) and feeds **S3/S4**.
+- [exercises/ex04_alphazero_math.md](exercises/ex04_alphazero_math.md) — the
+  outcome-with-draws value target and the noise-scaling rule.
+- [notes/silver-2017-alphago-zero.md](notes/silver-2017-alphago-zero.md) — the
+  baseline this paper is a diff against.
+
+**Legend.** Prompts marked 🔄 need synthesis with another source — answer them in
+[phase2-synthesis.md](notes/phase2-synthesis.md), not here.
+
+**Reading material** (extracted via `paper-study`, gitignored under
+`notes/sources/`): [manifest](sources/silver-2018-alphazero/manifest.json) ·
+[§1 main text](sources/silver-2018-alphazero/sections/01-mastering-chess-and-shogi-by-self-play-with-a-ge.md)
++ [Nível-1 companion](sources/silver-2018-alphazero/study/01-main-text.md) ·
+[§5 MCTS vs αβ](sources/silver-2018-alphazero/sections/05-mcts-and-alpha-beta-search.md) ·
+[§6 Domain Knowledge](sources/silver-2018-alphazero/sections/06-domain-knowledge.md) ·
+[§7 Representation](sources/silver-2018-alphazero/sections/07-representation.md)
++ [Nível-1 companion](sources/silver-2018-alphazero/study/07-representation.md) ·
+[§8 Configuration](sources/silver-2018-alphazero/sections/08-configuration.md) ·
+[§9 Evaluation](sources/silver-2018-alphazero/sections/09-evaluation.md).
+Level-1 companions for other sections on request.
+
+---
+
+## §1 — The general algorithm and its deltas from AlphaGo Zero
+
+### 1.1 — What generalises: one algorithm, three games
+**Prompt.** What does AlphaZero claim to hold *fixed* across chess, shogi, and Go
+(same network, same hyperparameters, same algorithm)? What is the single headline
+result and its caveat (compute, opponent used, single vs multiple runs)? Predict
+before reading: does the paper argue generality by *removing* Go-specific
+machinery, or by adding chess-specific machinery?
+
+**My take.**
+
+Before reading, I expected AlphaZero to extend AlphaGo Zero by introducing chess- or shogi-specific components. Instead, the paper argues for generality by removing Go-specific assumptions while keeping the learning algorithm essentially unchanged.
+
+Across chess, shogi, and Go, AlphaZero uses the same reinforcement learning framework, neural network architecture, Monte Carlo Tree Search procedure, and nearly identical training hyperparameters. The only game-dependent components are those that are unavoidable: the game rules, legal move generation, and the policy output representation required by each action space.
+
+The headline result is that a single algorithm, trained exclusively through self-play, achieves superhuman performance in all three games without handcrafted evaluation functions, opening books, endgame tablebases, or other domain-specific heuristics. This provides strong evidence that the AlphaGo Zero recipe is not limited to Go.
+
+However, the claim should be interpreted together with its practical caveats. The reported results rely on enormous computational resources, including thousands of TPUs for self-play and training, and the evaluation compares AlphaZero against the strongest available engines (Stockfish for chess, Elmo for shogi, and AlphaGo Zero for Go). Furthermore, the paper reports results from a single training run rather than multiple independent runs, so it does not assess training variance or reproducibility.
+
+For FLIPHEX, the most important takeaway is that AlphaZero validates the self-play + MCTS recipe in games where board symmetries are not assumed by the learning algorithm. Whether FLIPHEX possesses exploitable symmetries remains an open design question, but AlphaZero demonstrates that the framework does not depend on symmetry augmentation to achieve strong performance.
+
+**Refined write-up.**
+
+Your prediction-then-correction is exactly the paper's structure: generality by
+**subtraction**, not addition. One precision — "same hyperparameters" has a named
+exception the paper itself carves out: the Dirichlet α is scaled per game (you
+handle this in §4.1). And keep the compute figures straight: self-play used
+~5,000 first-generation TPUs; the "4 TPUs" is only the final single-machine
+evaluation. Your single-run caveat is the right one, and it is precisely what
+your H3 protocol will fix.
+
+### 1.2 — The concrete deltas (the S2 resolution) 🔄
+**Prompt.** Enumerate exactly what AlphaZero changes versus AlphaGo Zero. Cover at
+least: (a) game **outcome** now includes **draws** (chess/shogi) — how does the
+value target change? (b) the **evaluator gate** — is it kept or dropped, and what
+replaces it? (c) **symmetry augmentation** — kept or dropped, and why? For each,
+state the FLIPHEX consequence. This is synthesis **S2** — put the cross-paper
+reasoning there and summarise the verdict here.
+
+**My take.**
+
+AlphaZero is best understood as a minimal modification of AlphaGo Zero rather than a new algorithm. The self-play → MCTS → neural network training loop is preserved almost unchanged, while only a few assumptions tied specifically to Go are removed.
+
+The first change is the value target. AlphaGo Zero only considered terminal outcomes of win or loss, whereas AlphaZero extends the target to naturally include draws, which are common in chess. Instead of a binary outcome, the value target becomes {-1, 0, +1}, allowing the network to learn that forcing a draw can be preferable to pursuing a losing continuation. For FLIPHEX, however, this modification is not directly applicable because the game always produces a winner. The binary {-1, +1} outcome used by AlphaGo Zero already matches FLIPHEX's termination rules.
+
+The second—and arguably most consequential—change is the removal of the evaluator gate. AlphaGo Zero promoted a newly trained network only if it consistently defeated the current best network in a head-to-head evaluation. AlphaZero eliminates this promotion mechanism entirely and continuously trains from the latest network parameters. This simplifies the training pipeline while relying on gradient-based optimization to improve performance over time. For FLIPHEX, this appears to be the most directly transferable design decision, as maintaining an evaluation league would introduce considerable engineering complexity without clear empirical evidence that it improves learning.
+
+The third change is the complete removal of symmetry augmentation. AlphaGo Zero exploited the rotational and reflectional symmetries of the Go board to increase the effective training data. Chess and shogi lack comparable exploitable symmetries because piece movement and game semantics depend on orientation, making these transformations invalid. Consequently, AlphaZero trains directly on the original game positions without symmetry-based data augmentation. Whether FLIPHEX admits exploitable board symmetries remains an open question. However, AlphaZero demonstrates that symmetry augmentation is not a prerequisite for successful learning, making it a robust baseline regardless of the outcome of that future analysis.
+
+Taken together, these changes strengthen the paper's central claim. Rather than introducing domain-specific machinery for chess or shogi, AlphaZero systematically removes assumptions that were specific to Go. The result is not a fundamentally new algorithm, but a cleaner and more general reinforcement learning framework whose applicability depends less on the structural properties of a particular game.
+
+**Refined write-up.**
+
+All three deltas correct. Two connections. (a) The no-draw match for FLIPHEX is
+not merely convenient — it is *guaranteed* (25 cells, odd → draws impossible), so
+the `tanh` value head with `z ∈ {−1, +1}` transfers verbatim; drop the 0 case
+entirely. (b) You wrote that whether FLIPHEX has exploitable symmetries "remains
+an open question" — I computed the answer while reviewing this (see the chat
+note): the board graph has exactly one non-trivial automorphism, a **left-right
+mirror** (|Aut| = 2), and 180° is *not* one. So this paragraph's conclusion
+shifts: FLIPHEX is not symmetry-free like chess — it sits **between** chess (1×)
+and Go (8×), with a potential **2× mirror augmentation**, conditional on the
+chiral tile (OPEN-2) not breaking it. This is a genuine upgrade to the take.
+
+---
+
+## §2 — MCTS vs alpha-beta (§5)
+
+### 2.1 — Why the "slower" search wins 🔄
+**Prompt.** Chess engines were historically dominated by alpha-beta. What is the
+paper's argument for why MCTS + a learned evaluator beats a hand-tuned alpha-beta
+engine (Stockfish) here — think about evaluation error and how the two searches
+propagate it. Connect to FLIPHEX: this is the Axis 1 (exact/αβ) vs Axis 2 (MCTS)
+tension — answer the cross-source part in synthesis **S1/S4**.
+
+**My take.**
+
+The paper does not argue that Monte Carlo Tree Search is intrinsically superior to alpha-beta search. Instead, it argues that the effectiveness of a search algorithm depends on the quality of the evaluation function it propagates.
+
+Classical alpha-beta engines such as Stockfish compensate for imperfect evaluation functions by searching an enormous number of positions. Their strength comes from minimizing evaluation error through exhaustive search, carefully engineered heuristics, and decades of accumulated domain knowledge. In contrast, AlphaZero relies on a neural network that produces substantially more informative policy priors and value estimates. Because each evaluation is more accurate, MCTS can afford to explore only a tiny fraction of the positions considered by alpha-beta while still identifying stronger moves.
+
+The key insight is therefore not that MCTS searches deeper or faster, but that it allocates computation differently. Rather than attempting to reduce uncertainty through brute-force expansion, MCTS uses the learned policy to focus on promising continuations and the learned value function to estimate the quality of non-terminal positions. Search effort is concentrated where the network predicts it is most valuable, instead of being distributed according to handcrafted search heuristics.
+
+Importantly, this result should not be interpreted as evidence that MCTS universally dominates alpha-beta. The comparison is between complete systems rather than isolated search algorithms. AlphaZero combines MCTS with a powerful learned evaluator trained through self-play, whereas Stockfish combines alpha-beta with handcrafted evaluation, extensive domain knowledge, and decades of human refinement. The paper therefore demonstrates that a learned evaluation coupled with MCTS can outperform a highly optimized alpha-beta engine, not that MCTS alone is inherently superior.
+
+For FLIPHEX, this distinction is even more significant. Unlike chess, FLIPHEX has almost no accumulated strategic knowledge, no established evaluation heuristics, and only limited human play experience. Fundamental properties of the game remain unknown, including whether the first player has a forced win, whether the current board configuration is well balanced, and how alternative board sizes or tile distributions would affect strategic depth. Under these conditions, designing a strong alpha-beta evaluation function would require assumptions that cannot yet be justified empirically.
+
+From this perspective, AlphaZero is compelling not simply because it replaces alpha-beta with MCTS, but because it provides a framework for acquiring strategic knowledge directly through self-play instead of encoding that knowledge manually. More importantly, the same framework can be used not only to learn how to play FLIPHEX, but also to investigate the game itself by measuring first-player advantage, comparing alternative board designs, evaluating different tile layouts, and exploring whether the current rules produce a strategically rich and balanced game.
+
+**Refined write-up.**
+
+The sharpest thing in the note — you avoided the near-universal misreading
+("MCTS beats alpha-beta") and landed the paper's actual claim: **complete
+systems**, learned-eval + MCTS versus handcrafted-eval + αβ. One sharpening for
+the Axis-1 ↔ Axis-2 tension (synthesis **S4**): the AZ-beats-Stockfish result
+does **not** shrink your solver's role. Stockfish's evaluation is a heuristic;
+your Phase-3 solver on small variants produces the **exact game value** — ground
+truth no learned evaluator can claim. So the two axes are not "αβ vs MCTS"; they
+are "exact truth on small boards" cross-checking "strong approximate policy on
+the full board." That cross-check is the project's real contribution, and this
+reading strengthens it rather than blurring it.
+
+---
+
+## §3 — Domain knowledge and representation (§6, §7)
+
+### 3.1 — What AlphaZero still keeps
+**Prompt.** §6 lists the domain knowledge AlphaZero retains. How does this list
+differ from AGZ's four items (§8 of the AGZ note)? Specifically: what happens to
+the **symmetry** item, and what is added to handle chess's rules (castling, draws,
+repetition)? Which retained items does FLIPHEX also need?
+
+**My take.**
+
+Like AlphaGo Zero, AlphaZero deliberately minimizes domain-specific knowledge, but it updates the list to reflect the requirements of chess and shogi rather than Go. The retained knowledge consists only of information necessary to represent the game's rules and legal state, not handcrafted strategic expertise.
+
+Compared with AlphaGo Zero, the most notable change is the removal of symmetry augmentation. Go naturally admits rotational and reflectional symmetries that preserve game semantics, whereas chess and shogi do not because piece movement, promotion, and player orientation make these transformations invalid. Consequently, AlphaZero no longer assumes that symmetric board positions should be treated as equivalent.
+
+At the same time, AlphaZero extends the state representation to include rule-dependent information required by chess and shogi. This includes castling rights, repetition history, move counters, and other state variables needed to determine legal moves and game termination. These additions do not inject strategic knowledge; they simply ensure that the network observes the complete game state.
+
+This distinction is important. AlphaZero removes assumptions that are specific to Go while retaining only those aspects of domain knowledge that are logically required to define the game itself. The algorithm therefore depends on an accurate representation of the rules, but not on handcrafted evaluation functions or expert strategic concepts.
+
+For FLIPHEX, the same principle should apply. The input representation should encode every variable necessary to reconstruct the legal game state, while avoiding features that embed human strategic intuition. Any rule-specific state—such as tile orientation, remaining legal actions, or other game-dependent variables—belongs in the representation, whereas handcrafted notions of "good positions" should instead emerge through self-play.
+
+**Refined write-up.**
+
+Right principle: encode the rules completely, let strategy emerge. The one place
+to revise is your symmetry sentence — you say chess/shogi "lack comparable
+exploitable symmetries," implying FLIPHEX patterns with them. It does **not**:
+the computed board automorphism group is Z/2 (a mirror), so in this paragraph's
+taxonomy FLIPHEX sits between Go and chess, not alongside chess. See the chat
+note — an upgrade to the take, not a correction of the principle.
+
+### 3.2 — The input tensor and the structured policy head (R5 evidence)
+**Prompt.** This is the most FLIPHEX-relevant section. Describe: (a) the input
+plane stack for chess (piece planes, repetition, castling, move count) — how does
+it compare to AGZ's 17 Go planes and to your FLIPHEX plane list (§5.2 of the AGZ
+note)? (b) The **policy head**: chess uses **8×8×73** planes (a *from-square* ×
+*move-type* factoring), shogi similar. Is this the empirical precedent adr-005's
+(cell × tile × rotation) factoring was missing? State the honest verdict for R5
+now that a real factored head exists in the literature.
+
+**My take.**
+
+This section is the strongest empirical support for ADR-005. Before reading AlphaZero, the proposed FLIPHEX policy representation—factoring actions into (cell × tile × rotation)—was motivated primarily by engineering intuition. AlphaZero demonstrates that this design principle has already been successfully applied in large action spaces.
+
+Like AlphaGo Zero, AlphaZero represents the game state as a stack of feature planes. However, the chess representation is considerably richer because the rules require additional state variables beyond piece locations. Besides encoding piece positions over a history of previous states, the input includes information such as repetition history, castling rights, side to move, and move counters. These features do not express strategic knowledge; they simply provide the network with a complete description of the legal game state. The underlying design principle therefore remains unchanged: encode rules completely, but allow strategy to emerge through learning.
+
+The most important contribution, however, is the policy head. Instead of treating every legal move as an independent output class, AlphaZero represents chess moves as an 8×8×73 tensor. Each prediction is factored into a source square and a move type, allowing the network to exploit the inherent structure of the action space while still producing a fixed-size policy output. Shogi adopts the same idea with a different factorization appropriate for its own move representation.
+
+This provides exactly the kind of empirical precedent that ADR-005 was missing. Although the specific factors differ, the underlying principle is identical: represent actions as the Cartesian product of semantically meaningful components instead of enumerating every possible move independently. FLIPHEX's proposed (cell × tile × rotation) representation follows the same philosophy, adapting the factorization to the structure of its action space rather than copying the chess encoding itself.
+
+The evidence therefore strengthens R5 considerably. AlphaZero does not merely show that structured policy heads are possible; it demonstrates that they scale successfully to complex board games with large action spaces. While this does not prove that FLIPHEX's particular factorization is optimal, it provides a strong empirical justification for treating structured action representations as a sound architectural design principle rather than an ad hoc engineering decision.
+
+**Refined write-up.**
+
+Strong — and this is where you asked me to be critical, so: you slightly
+overstate. The same §7 reports an ablation you did not cite: *"We also tried
+using a flat distribution over moves for chess and shogi; the final result was
+almost identical although training was slightly slower."* So the honest R5
+verdict is two-sided: (1) structured heads are validated and shown to scale
+(supports adr-005), **but** (2) the paper's own test shows a flat head reaches
+nearly the same final strength — so factoring is a training-efficiency
+optimization, not a correctness requirement. That is the best possible R5
+outcome: your factored head is well-precedented *and* has a documented safe
+fallback (flat) if it ever complicates. Citing the ablation makes the case more
+credible, not less — it turns "strongest empirical support" into "well-precedented
+choice with a known escape hatch," which is what an ADR wants.
+
+---
+
+## §4 — Configuration and evaluation (§8, §9)
+
+### 4.1 — Hyperparameters, and Dirichlet noise scaled to legal moves
+**Prompt.** §8 gives the search/training configuration. Find how the **Dirichlet
+noise α** is set for each game — the paper scales it to the typical number of
+legal moves (α ≈ 0.3 for chess, 0.15 shogi, 0.03 Go). Why does α shrink as the
+branching factor grows, and what α would that rule imply for FLIPHEX? (This is the
+concrete fix flagged in the AGZ §6.3 refinement — bank the rule, not the constant.)
+
+**My take.**
+
+Rather than treating the Dirichlet noise parameter as a game-specific constant, AlphaZero presents it as a quantity that should scale with the typical number of legal moves. The reported values follow a clear pattern: approximately α = 0.30 for chess, α = 0.15 for shogi, and α = 0.03 for Go. Since Go has by far the largest branching factor, it receives the smallest concentration parameter.
+
+The rationale becomes clearer when considering the role of the Dirichlet distribution. At the root node, exploration noise is added to the policy prior to encourage self-play to sample moves beyond those currently preferred by the network. As the number of legal actions increases, the same total amount of exploratory probability must be distributed across more candidates. Reducing α makes the injected noise remain appropriately sparse, preventing exploration from becoming nearly uniform over an excessively large action space. Conversely, games with fewer legal moves can use a larger α without overwhelming the learned policy.
+
+The important lesson is therefore the scaling rule rather than the numerical constants themselves. AlphaZero suggests that the concentration parameter should be chosen relative to the typical branching factor of the game, ensuring that root exploration has a comparable qualitative effect across domains.
+
+For FLIPHEX, this implies that α should not be copied directly from either AlphaGo Zero or AlphaZero. Instead, it should be estimated from the game's average number of legal moves. Since the current FLIPHEX implementation has approximately 1,450 legal opening actions, substantially more than the games studied in the paper, the corresponding α would likely need to be smaller than Go's 0.03 to preserve a similar exploration profile. The exact value should ultimately be treated as a tunable hyperparameter, but the paper provides a principled initialization rule based on branching factor rather than an arbitrary constant.
+
+**Refined write-up.**
+
+Scaling reasoning correct. Two sharpenings. (1) A common way to interpolate the
+paper's three points is α ≈ 10 / (typical legal moves) — but flag it as a
+**community heuristic** (KataGo and others), *not* stated in the paper; the paper
+gives only {0.3, 0.15, 0.03} scaled inversely to legal moves. (2) Critical catch:
+you plugged in **1,450**, but that is the *first-ply* count. AZ scales α to the
+*typical* branching over a whole game, not the opening peak — and FLIPHEX's
+branching collapses fast as the 25 cells fill. Using 1,450 would set α far too
+small and starve mid-game exploration. Measure the **average** legal-move count
+across a self-play game first (a quick histogram — the smoke script already walks
+random games), then set α from that average, not from the opening.
+
+### 4.2 — Evaluation and its rigor
+**Prompt.** How is AlphaZero evaluated (opponent, time controls, number of games,
+Elo method)? What are the acknowledged threats to a fair comparison with Stockfish
+(hardware, opening books, time)? What would you replicate — and what would you do
+*differently* — for FLIPHEX's H3, given the AGZ single-run critique still applies?
+
+**My take.**
+
+AlphaZero evaluates its playing strength by competing against the strongest available conventional engines for each game: Stockfish for chess, Elmo for shogi, and AlphaGo Zero for Go. Matches are played under fixed time controls, and player strength is estimated using Elo ratings derived from the game results. The evaluation is therefore practical rather than theoretical: the question is whether the trained system consistently wins against state-of-the-art opponents.
+
+The paper also acknowledges that achieving a perfectly fair comparison is difficult. AlphaZero and Stockfish run on fundamentally different hardware, with AlphaZero relying on large TPU infrastructure while Stockfish runs on conventional CPUs. In addition, Stockfish's opening book and endgame tablebases are disabled to compare search algorithms rather than accumulated human knowledge. Time controls are equalized as much as possible, but computational resources remain inherently asymmetric because the two systems perform very different types of computation.
+
+Despite these precautions, the evaluation has important methodological limitations. Like AlphaGo Zero, AlphaZero reports the outcome of a single successful training run rather than multiple independent replications. As a result, the paper demonstrates that the algorithm can achieve superhuman performance, but provides little evidence about training variance, reproducibility, or sensitivity to initialization and hyperparameter choices.
+
+For FLIPHEX, I would replicate the general evaluation philosophy while strengthening its experimental rigor. A fixed benchmark opponent, standardized search budgets, and Elo-style ratings remain appropriate for measuring playing strength. However, I would additionally train multiple independent agents with different random seeds, report confidence intervals over match results, and measure variability across training runs. Since FLIPHEX is itself an evolving game, I would also extend the evaluation beyond playing strength by comparing different board layouts, tile distributions, and rule variants under the same evaluation protocol. In this setting, self-play becomes not only a way to evaluate agents, but also a methodology for evaluating the game design itself.
+
+**Refined write-up.**
+
+Excellent, and the multi-seed + design-evaluation extension is exactly right. One
+precision: the multi-seed/CI rigor is not really an *extension* of H3 — it is
+already latent in H3's original wording ("a stable win-rate distribution across
+independent training runs … agrees within Wilson CI"). You are making H3 honest,
+not enlarging it. The "compare board layouts / tile distributions / rule variants"
+half is bigger than H3 and belongs with H1/H2/H5 under the motivation reframe —
+see the TODO verdict in chat, where I argue it is the strongest of your three
+notes but needs scoping so it does not blow the compute budget.
+
+---
+
+## §5 — Limitations and what does not transfer
+
+### 5.1 — The authors' concessions
+**Prompt.** What does the paper concede about generality, compute, and the
+fairness of the Stockfish match? Which limitation is *load-bearing* for FLIPHEX —
+and does anything here change the transfer verdict you reached in §8.2 of the AGZ
+note (that assumptions, not compute, are what matter)?
+
+**My take.**
+
+Although AlphaZero presents a remarkably general reinforcement learning framework, the paper is careful not to claim unlimited generality. Its conclusions are supported only for deterministic, perfect-information, two-player zero-sum board games. Whether the same approach transfers to games with hidden information, stochastic dynamics, or multiplayer interactions remains outside the scope of the work.
+
+The paper also makes clear that its results rely on extraordinary computational resources. Large-scale TPU infrastructure enables millions of self-play games and repeated neural network updates within practical time. This level of compute is clearly inaccessible to most researchers and should be viewed as an experimental condition rather than an assumption of the algorithm itself.
+
+The comparison against Stockfish is likewise presented with appropriate caveats. Although opening books and endgame tablebases are disabled to isolate the search algorithms, the two systems run on fundamentally different hardware and implement different computational strategies. Consequently, the evaluation demonstrates competitive playing strength under a carefully designed experimental setup rather than proving the intrinsic superiority of one search algorithm over another.
+
+For FLIPHEX, however, none of these limitations changes the central transfer argument established after studying AlphaGo Zero. The most valuable contribution of AlphaZero is not its computational scale but the architectural principles that remain valid under far smaller budgets: self-play reinforcement learning, neural-guided MCTS, structured policy representations, and learning strategic knowledge instead of encoding it manually.
+
+In fact, the FLIPHEX context makes this distinction even more important. The primary challenge is not reproducing DeepMind's level of compute, but understanding a game whose strategic properties are still largely unexplored. Questions such as first-player advantage, board balance, action-space design, and strategic depth remain open regardless of available hardware. AlphaZero therefore transfers primarily as a research methodology rather than as a blueprint for reproducing DeepMind's computational scale. The assumptions behind the algorithm remain the load-bearing contribution; the compute budget determines only how efficiently those assumptions can be explored.
+
+**Refined write-up.**
+
+Correct, and it lands the AGZ §8.2 verdict cleanly: assumptions are load-bearing,
+compute is not. One thing to add: the assumptions AZ needs (deterministic,
+perfect-information, cheap to simulate, known terminal/scoring) are all satisfied
+by FLIPHEX — *and*, unlike chess, FLIPHEX additionally has an **exact solver**
+available on small variants. So you are strictly better off than the AZ setting
+for *validation*: you can check the learned policy against ground truth, which
+DeepMind could not. Compute limits how fast you explore; it does not threaten
+correctness — and the solver gives you a correctness oracle chess never had.
+
+---
+
+## Lessons Learned
+
+Reading AlphaZero fundamentally changed how I think about applying reinforcement learning to FLIPHEX.
+
+The first change concerns **transferability**. AlphaZero demonstrates that the key ideas of the AlphaGo Zero framework are not tied to Go. Self-play reinforcement learning, neural-guided MCTS, and structured policy representations transfer successfully to games without exploitable board symmetries. This shifted my perspective from asking whether FLIPHEX "looks like Go" to asking whether it satisfies the algorithmic assumptions that actually matter.
+
+The second change is the role of **structured policy heads**. Before this reading, the proposed (cell × tile × rotation) action representation in ADR-005 was primarily an engineering intuition. AlphaZero provides a concrete empirical precedent: chess and shogi both factor actions into semantically meaningful components rather than enumerating every legal move independently. This substantially strengthens the architectural justification for FLIPHEX's proposed policy representation.
+
+Perhaps the most important insight, however, is that AlphaZero is valuable even beyond learning to play FLIPHEX. Since FLIPHEX has very limited accumulated strategic knowledge, many basic questions remain unanswered, including first-player advantage, board balance, action-space design, and the effect of alternative board geometries or tile distributions. This suggests a broader research direction: use self-play not only to train an agent, but also as a computational methodology for investigating and improving the game itself.
+
+Finally, this paper reinforced a distinction established while reading AlphaGo Zero: the transferable contribution is the learning framework and its assumptions—not DeepMind's computational scale. Large-scale TPUs explain how quickly AlphaZero reached its results, but they are not the reason the underlying ideas transfer to new games.
+
+## Failed Attempts
+
+Several assumptions made before reading AlphaZero were revised.
+
+Initially, I viewed the main architectural decision as choosing between alpha-beta search and MCTS. After studying the comparison with Stockfish, this framing appears incomplete. For FLIPHEX, the more fundamental question is whether enough strategic knowledge exists to engineer a strong evaluation function at all. Given the current state of the game, self-play appears more attractive because it acquires strategic knowledge rather than assuming it already exists.
+
+I also initially treated the absence of board symmetries in FLIPHEX as an established fact. After revisiting the game's geometry, I realized this is still a hypothesis rather than a verified property. Whether exploitable symmetries exist remains an open research question, although AlphaZero demonstrates that the learning framework does not depend on symmetry augmentation.
+
+Another revision concerns evaluation. My original focus was measuring agent strength, but AlphaZero suggests a broader role for evaluation. Since FLIPHEX itself is still being studied, the experimental protocol should also support comparing board layouts, tile distributions, rule variants, and training stability across independent runs.
+
+Finally, I originally viewed AlphaZero as a target implementation. After completing this reading, it seems more appropriate to view it as a research methodology for computational game design, using reinforcement learning to understand the properties of FLIPHEX before treating its current rule set as fixed.

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -107,20 +107,25 @@ direction `d` if and only if `Y` neighbours `X` in direction `d + 3`.
   is a candidate move-ordering signal for the Phase 3 solver.
 - The two degree-2 cells are `A1` and `E1`, the poorest cells on the board.
 
-### The board is not centrally symmetric — and that matters
+### The board has a single mirror symmetry — and that matters
 
 Columns A, C, E carry cells at vertical offsets 0..4 while B and D sit at
-0.5..4.5. Those two sets of columns have different vertical centres (2 and
-2.5), so no rotation or reflection maps the cell set onto itself: the board's
-symmetry group is **trivial**. The shape "leans". Concretely `C1` has degree 3
-while `C5` has degree 5, and `A1`/`E1` (degree 2) have no degree-2 partners
-under any candidate symmetry.
+0.5..4.5. Those two column groups have different vertical centres (2 and 2.5),
+so no symmetry can *mix* them — that rules out 90° rotation, a top-bottom
+mirror, and 180° rotation. But one symmetry survives *within* the groups: a
+**left-right mirror across column C** (`A`↔`E`, `B`↔`D`, `C` fixed; and
+`NE`↔`NW`, `SE`↔`SW`). The board's automorphism group is therefore **Z/2**, not
+trivial. Consistently, `A1` and `E1` — the two degree-2 cells — are each other's
+mirror image, and `C1`/`C5` lie on the axis and are fixed. Verified by
+`scripts/check_symmetry.py`; recorded in `docs/adr/adr-008-board-mirror-symmetry.md`.
 
-This is a real asymmetry in the physical artifact, not a modelling artifact,
-and it is directly relevant to **H1 (first-player advantage)**: on a board with
-no symmetry group, there is no strategy-stealing or pairing argument available,
-so H1 has to be settled computationally. Worth stating explicitly in the
-writeup — it is part of why the game is interesting.
+The mirror is a symmetry of the geometry and the flip rule; whether the *game*
+inherits it hinges on the chiral `P3-y` tile (`OPEN-2`). If it does, self-play
+gains a 2× data augmentation and transposition keys can be mirror-canonicalised.
+For **H1 (first-player advantage)** the mirror changes nothing: it preserves the
+player to move, so it is not a colour swap and gives no strategy-stealing or
+pairing argument. H1 must still be settled computationally — the conclusion the
+Phase 0 note reached, though its "no symmetry" premise was wrong.
 
 > **OPEN-1.** Confirm against the physical board that all five columns really
 > hold five cells and that no cell is missing from a corner. The poster

--- a/scripts/check_mirror_game_symmetry.py
+++ b/scripts/check_mirror_game_symmetry.py
@@ -176,17 +176,23 @@ def part_b(board: Board, pi: tuple[int, ...], rho: dict[int, int]) -> None:
     print(f"   moves whose mirror is NOT legal ....... {len(without)}")
     all_chiral = all(m.tile == chiral_idx for m in without)
     print(f"   ... all of them play {CHIRAL}? ......... {all_chiral}")
-    print(f"   = 25 cells x {len(orbit(chiral_idx))} rotations ............... "
-          f"{board.n_cells * len(orbit(chiral_idx))}")
+    print(
+        f"   = 25 cells x {len(orbit(chiral_idx))} rotations ............... "
+        f"{board.n_cells * len(orbit(chiral_idx))}"
+    )
     assert all(m.tile == chiral_idx for m in without)
     assert len(without) == board.n_cells * len(orbit(chiral_idx))
 
     bad = without[0]
     pattern = TILES[bad.tile].rotated(bad.rotation)
-    print(f"\n   witness: play {CHIRAL} on cell {board.cell_name(bad.cell)} at "
-          f"rotation {bad.rotation}, arrows {fmt(pattern)}")
-    print(f"            its mirror needs arrows {fmt(mirror_mask(pattern, rho))} "
-          f"on cell {board.cell_name(pi[bad.cell])}")
+    print(
+        f"\n   witness: play {CHIRAL} on cell {board.cell_name(bad.cell)} at "
+        f"rotation {bad.rotation}, arrows {fmt(pattern)}"
+    )
+    print(
+        f"            its mirror needs arrows {fmt(mirror_mask(pattern, rho))} "
+        f"on cell {board.cell_name(pi[bad.cell])}"
+    )
     print("            no tile in the deck presents that pattern at any rotation.")
 
 

--- a/scripts/check_mirror_game_symmetry.py
+++ b/scripts/check_mirror_game_symmetry.py
@@ -1,0 +1,258 @@
+"""Test whether the board's Z/2 mirror is also a symmetry of the *game*.
+
+``scripts/check_symmetry.py`` establishes that the board graph has a single
+non-trivial automorphism: a left-right **mirror** across column C, acting on
+directions by ``NE<->NW``, ``SE<->SW`` (``adr-008``). That is a statement about
+geometry and the flip rule only.
+
+A *game* symmetry is stronger. Writing ``M`` for the mirror, it requires that
+for every state ``s`` and every move ``a``::
+
+    a is legal in s   <=>   M(a) is legal in M(s)
+    M(RESULT(s, a))    ==   RESULT(M(s), M(a))
+
+The first line is where FLIPHEX fails, and this script exhibits exactly why and
+exactly when it recovers.
+
+The mechanism: a hex tile on the board may be **rotated** but never reflected
+(turning it over would change its colour), so the patterns a tile can present
+are its *rotation orbit*. The mirror reflects patterns. For a tile whose orbit
+is closed under reflection this is harmless -- the mirrored pattern is just
+another rotation of the same tile. ``P3-y`` is **chiral**: its reflection is a
+different rotation orbit, and no tile in the deck can produce it. So a move that
+plays ``P3-y`` has no mirror image among the legal moves.
+
+Consequence, and it is the one the synthesis note (S3) turns on: the mirror is a
+*partial*, endgame-restricted symmetry. It becomes a genuine game symmetry only
+once **both** copies of ``P3-y`` have been placed and gone inert.
+
+    python scripts/check_mirror_game_symmetry.py
+
+Exits non-zero if any claim fails.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_symmetry import board_automorphisms  # noqa: E402
+
+from fliphex.board import Board  # noqa: E402
+from fliphex.moves import Move, apply_move, legal_moves  # noqa: E402
+from fliphex.piece import N_SLOTS, mask_to_slots  # noqa: E402
+from fliphex.state import (  # noqa: E402
+    TILE_INDEX,
+    TILES,
+    Colour,
+    GameState,
+    tiles_in,
+)
+
+CHIRAL = "P3-y"
+
+
+# -- the mirror, derived from the board rather than hard-coded ----------------
+
+
+def mirror_of(board: Board) -> tuple[tuple[int, ...], dict[int, int]]:
+    """Return the board's non-identity automorphism as ``(cells, directions)``.
+
+    ``board_automorphisms`` yields ``(name, direction_permutation, cell_map)``
+    where ``cell_map`` is a *dict*. Identity is filtered on the permutation
+    itself, not on the action name -- several named actions can induce it.
+    """
+    identity = tuple(range(board.n_cells))
+    autos = []
+    for _name, rho, cell_map in board_automorphisms(board):
+        perm = tuple(cell_map[c] for c in range(board.n_cells))
+        if perm != identity:
+            autos.append((perm, {d: rho[d] for d in range(N_SLOTS)}))
+    if len(autos) != 1:
+        raise AssertionError(f"expected exactly one non-trivial automorphism, got {len(autos)}")
+    return autos[0]
+
+
+def mirror_mask(mask: int, rho: dict[int, int]) -> int:
+    """Reflect an arrow pattern: arrow in slot ``i`` moves to slot ``rho[i]``."""
+    out = 0
+    for i in range(N_SLOTS):
+        if mask >> i & 1:
+            out |= 1 << rho[i]
+    return out
+
+
+def orbit(tile: int) -> set[int]:
+    """Every arrow pattern this tile can present, over its distinct rotations."""
+    return {TILES[tile].rotated(r) for r in TILES[tile].distinct_rotations()}
+
+
+def find_placement(hand: int, pattern: int) -> tuple[int, int] | None:
+    """Return a ``(tile, rotation)`` in ``hand`` presenting ``pattern``, if any."""
+    for tile in tiles_in(hand):
+        for rotation in TILES[tile].distinct_rotations():
+            if TILES[tile].rotated(rotation) == pattern:
+                return tile, rotation
+    return None
+
+
+def mirror_move(move: Move, hand: int, pi: tuple[int, ...], rho: dict[int, int]) -> Move | None:
+    """Return the mirror image of ``move``, or ``None`` if no tile can play it.
+
+    The mirrored move must land on the mirrored cell and present the mirrored
+    arrow pattern. Which *tile* realises it is not fixed in advance -- we ask
+    the hand.
+    """
+    pattern = mirror_mask(TILES[move.tile].rotated(move.rotation), rho)
+    found = find_placement(hand, pattern)
+    if found is None:
+        return None
+    tile, rotation = found
+    return Move(pi[move.cell], tile, rotation)
+
+
+def mirror_state(state: GameState, pi: tuple[int, ...]) -> GameState:
+    """Mirror a position. Hands are unchanged -- you hold the same tiles."""
+    colours = [Colour.EMPTY] * state.n_cells
+    for cell, colour in enumerate(state.colours):
+        colours[pi[cell]] = colour
+    return GameState.build(tuple(colours), state.hands, state.to_move)
+
+
+def fmt(mask: int) -> str:
+    names = ("N", "NE", "SE", "S", "SW", "NW")
+    return "{" + ",".join(names[s] for s in mask_to_slots(mask)) + "}"
+
+
+# -- part A: which archetypes survive reflection ------------------------------
+
+
+def part_a(rho: dict[int, int]) -> list[str]:
+    print("=" * 74)
+    print("A. Is each tile's rotation orbit closed under the mirror?")
+    print("=" * 74)
+    print(f"   mirror on directions: {', '.join(f'{d}->{rho[d]}' for d in range(N_SLOTS))}")
+    print(f"   {'tile':<9} {'rotations':>9}  {'orbit closed?':<14} mirror of canonical")
+    broken = []
+    for tile, piece in enumerate(TILES):
+        orb = orbit(tile)
+        mirrored = {mirror_mask(m, rho) for m in orb}
+        closed = mirrored == orb
+        if not closed:
+            broken.append(piece.archetype)
+            if mirrored & orb:
+                raise AssertionError("partial overlap is impossible for a group action")
+        flag = "yes" if closed else "NO  <-- chiral"
+        print(
+            f"   {piece.archetype:<9} {len(orb):>9}  {flag:<14} "
+            f"{fmt(piece.mask)} -> {fmt(mirror_mask(piece.mask, rho))}"
+        )
+    print(f"\n   -> chiral tiles: {broken or 'none'}")
+    assert broken == [CHIRAL], f"expected only {CHIRAL} to be chiral, got {broken}"
+    return broken
+
+
+# -- part B: what that costs at the move level --------------------------------
+
+
+def part_b(board: Board, pi: tuple[int, ...], rho: dict[int, int]) -> None:
+    print("\n" + "=" * 74)
+    print("B. Opening ply: how many of the 1450 legal moves have a legal mirror?")
+    print("=" * 74)
+    state = GameState.initial(board.n_cells)
+    hand = state.hand(state.to_move)
+    moves = legal_moves(board, state)
+    without = [m for m in moves if mirror_move(m, hand, pi, rho) is None]
+    chiral_idx = TILE_INDEX[CHIRAL]
+
+    print(f"   legal moves on ply 1 .................. {len(moves)}")
+    print(f"   moves whose mirror is NOT legal ....... {len(without)}")
+    print(f"   ... all of them play {CHIRAL}? ......... {all(m.tile == chiral_idx for m in without)}")
+    print(f"   = 25 cells x {len(orbit(chiral_idx))} rotations ............... "
+          f"{board.n_cells * len(orbit(chiral_idx))}")
+    assert all(m.tile == chiral_idx for m in without)
+    assert len(without) == board.n_cells * len(orbit(chiral_idx))
+
+    bad = without[0]
+    pattern = TILES[bad.tile].rotated(bad.rotation)
+    print(f"\n   witness: play {CHIRAL} on cell {board.cell_name(bad.cell)} at rotation "
+          f"{bad.rotation}, arrows {fmt(pattern)}")
+    print(f"            its mirror needs arrows {fmt(mirror_mask(pattern, rho))} on cell "
+          f"{board.cell_name(pi[bad.cell])}")
+    print("            no tile in the deck presents that pattern at any rotation.")
+
+
+# -- part C: the scenario, before and after both P3-y are spent ---------------
+
+
+def _twin_positions(board: Board, chiral_in_hand: bool) -> GameState:
+    """A small hand-built position; both players hold the same tiles."""
+    colours = [Colour.EMPTY] * board.n_cells
+    for name, colour in (("B2", Colour.PURPLE), ("D4", Colour.GREEN)):
+        colours[board.cell_id(name)] = colour
+    keep = ["P1", "P2-adj", "P6"] + ([CHIRAL] if chiral_in_hand else [])
+    hand = 0
+    for name in keep:
+        hand |= 1 << TILE_INDEX[name]
+    return GameState.build(tuple(colours), (hand, hand), Colour.PURPLE)
+
+
+def part_c(board: Board, pi: tuple[int, ...], rho: dict[int, int]) -> None:
+    print("\n" + "=" * 74)
+    print("C. The same position, with and without P3-y in hand")
+    print("=" * 74)
+    for chiral_in_hand in (True, False):
+        state = _twin_positions(board, chiral_in_hand)
+        hand = state.hand(state.to_move)
+        held = ", ".join(TILES[t].archetype for t in tiles_in(hand))
+        moves = legal_moves(board, state)
+        mirrored = [mirror_move(m, hand, pi, rho) for m in moves]
+        missing = sum(1 for m in mirrored if m is None)
+
+        # Where a mirror image exists, does the diagram commute?
+        ms = mirror_state(state, pi)
+        legal_after = set(legal_moves(board, ms))
+        commutes = True
+        for move, mm in zip(moves, mirrored, strict=True):
+            if mm is None:
+                continue
+            if mm not in legal_after:
+                commutes = False
+                break
+            lhs = mirror_state(apply_move(board, state, move), pi)
+            rhs = apply_move(board, ms, mm)
+            if lhs.colours != rhs.colours:
+                commutes = False
+                break
+
+        print(f"\n   hand = {held}")
+        print(f"     legal moves ......................... {len(moves)}")
+        print(f"     without a legal mirror image ........ {missing}")
+        print(f"     M(RESULT(s,a)) == RESULT(M(s),M(a)) . {commutes} (where M(a) exists)")
+        print(f"     => mirror is a game symmetry here ... {missing == 0 and commutes}")
+        assert commutes, "the flip rule itself must commute with the mirror"
+        if chiral_in_hand:
+            assert missing > 0, "expected the chiral tile to break the mirror"
+        else:
+            assert missing == 0, "expected the mirror to hold once P3-y is spent"
+
+
+def main() -> int:
+    board = Board()
+    pi, rho = mirror_of(board)
+    part_a(rho)
+    part_b(board, pi, rho)
+    part_c(board, pi, rho)
+    print("\n" + "=" * 74)
+    print("VERDICT: the mirror preserves the board, the arrow structure and the")
+    print("flip rule -- but not the *move set*, while a P3-y is in either hand.")
+    print("It is a full game symmetry only after both copies are placed, i.e.")
+    print("in the endgame, which is where the retrograde databases live.")
+    print("=" * 74)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_mirror_game_symmetry.py
+++ b/scripts/check_mirror_game_symmetry.py
@@ -71,7 +71,9 @@ def mirror_of(board: Board) -> tuple[tuple[int, ...], dict[int, int]]:
         if perm != identity:
             autos.append((perm, {d: rho[d] for d in range(N_SLOTS)}))
     if len(autos) != 1:
-        raise AssertionError(f"expected exactly one non-trivial automorphism, got {len(autos)}")
+        raise AssertionError(
+            f"expected exactly one non-trivial automorphism, got {len(autos)}"
+        )
     return autos[0]
 
 
@@ -98,7 +100,9 @@ def find_placement(hand: int, pattern: int) -> tuple[int, int] | None:
     return None
 
 
-def mirror_move(move: Move, hand: int, pi: tuple[int, ...], rho: dict[int, int]) -> Move | None:
+def mirror_move(
+    move: Move, hand: int, pi: tuple[int, ...], rho: dict[int, int]
+) -> Move | None:
     """Return the mirror image of ``move``, or ``None`` if no tile can play it.
 
     The mirrored move must land on the mirrored cell and present the mirrored
@@ -133,7 +137,8 @@ def part_a(rho: dict[int, int]) -> list[str]:
     print("=" * 74)
     print("A. Is each tile's rotation orbit closed under the mirror?")
     print("=" * 74)
-    print(f"   mirror on directions: {', '.join(f'{d}->{rho[d]}' for d in range(N_SLOTS))}")
+    moved = ", ".join(f"{d}->{rho[d]}" for d in range(N_SLOTS))
+    print(f"   mirror on directions: {moved}")
     print(f"   {'tile':<9} {'rotations':>9}  {'orbit closed?':<14} mirror of canonical")
     broken = []
     for tile, piece in enumerate(TILES):
@@ -169,7 +174,8 @@ def part_b(board: Board, pi: tuple[int, ...], rho: dict[int, int]) -> None:
 
     print(f"   legal moves on ply 1 .................. {len(moves)}")
     print(f"   moves whose mirror is NOT legal ....... {len(without)}")
-    print(f"   ... all of them play {CHIRAL}? ......... {all(m.tile == chiral_idx for m in without)}")
+    all_chiral = all(m.tile == chiral_idx for m in without)
+    print(f"   ... all of them play {CHIRAL}? ......... {all_chiral}")
     print(f"   = 25 cells x {len(orbit(chiral_idx))} rotations ............... "
           f"{board.n_cells * len(orbit(chiral_idx))}")
     assert all(m.tile == chiral_idx for m in without)
@@ -177,10 +183,10 @@ def part_b(board: Board, pi: tuple[int, ...], rho: dict[int, int]) -> None:
 
     bad = without[0]
     pattern = TILES[bad.tile].rotated(bad.rotation)
-    print(f"\n   witness: play {CHIRAL} on cell {board.cell_name(bad.cell)} at rotation "
-          f"{bad.rotation}, arrows {fmt(pattern)}")
-    print(f"            its mirror needs arrows {fmt(mirror_mask(pattern, rho))} on cell "
-          f"{board.cell_name(pi[bad.cell])}")
+    print(f"\n   witness: play {CHIRAL} on cell {board.cell_name(bad.cell)} at "
+          f"rotation {bad.rotation}, arrows {fmt(pattern)}")
+    print(f"            its mirror needs arrows {fmt(mirror_mask(pattern, rho))} "
+          f"on cell {board.cell_name(pi[bad.cell])}")
     print("            no tile in the deck presents that pattern at any rotation.")
 
 
@@ -230,7 +236,7 @@ def part_c(board: Board, pi: tuple[int, ...], rho: dict[int, int]) -> None:
         print(f"\n   hand = {held}")
         print(f"     legal moves ......................... {len(moves)}")
         print(f"     without a legal mirror image ........ {missing}")
-        print(f"     M(RESULT(s,a)) == RESULT(M(s),M(a)) . {commutes} (where M(a) exists)")
+        print(f"     M(RESULT(s,a)) == RESULT(M(s),M(a)) . {commutes} (where defined)")
         print(f"     => mirror is a game symmetry here ... {missing == 0 and commutes}")
         assert commutes, "the flip rule itself must commute with the mirror"
         if chiral_in_hand:

--- a/scripts/check_symmetry.py
+++ b/scripts/check_symmetry.py
@@ -1,0 +1,121 @@
+"""Compute the automorphism group of the FLIPHEX board as a directed hex graph.
+
+A board *symmetry* is a pair ``(pi, rho)`` where ``pi`` permutes the cells and
+``rho`` is one of the twelve dihedral (``D6``) actions on the six arrow
+directions, such that for every cell ``u`` and direction ``d``::
+
+    neighbour(pi(u), rho(d)) == pi(neighbour(u, d))
+
+with :data:`~fliphex.board.OFF_BOARD` mapping to itself. This is exactly a
+relabelling that preserves both adjacency *and* the arrow-direction structure
+the flip rule depends on — i.e. a symmetry a solver or self-play pipeline could
+legitimately exploit for canonicalisation or data augmentation.
+
+Result on the full 5x5 board: the group has order 2 — the identity and a single
+left-right **mirror** across column C. 180-degree rotation is *not* a symmetry.
+See ``docs/adr/adr-008-board-mirror-symmetry.md``.
+
+    python scripts/check_symmetry.py          # full board
+    python scripts/check_symmetry.py 3 3      # a reduced variant
+
+Note: this is a symmetry of the board geometry and the flip rule only. Whether
+the *game* inherits it depends on the chiral ``P3-y`` tile (OPEN-2), since the
+mirror reflects arrow patterns and the deck is closed under reflection except
+for that one chiral piece.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from fliphex.board import DIRECTION_NAMES, OFF_BOARD, Board  # noqa: E402
+
+#: A cell permutation together with the direction action that induces it.
+Automorphism = tuple[str, tuple[int, ...], dict[int, int]]
+
+
+def _dihedral_direction_actions() -> list[tuple[str, tuple[int, ...]]]:
+    """The twelve D6 actions on directions 0..5: 6 rotations + 6 reflections."""
+    actions: list[tuple[str, tuple[int, ...]]] = []
+    for k in range(6):
+        actions.append((f"rot{k * 60}", tuple((d + k) % 6 for d in range(6))))
+    for k in range(6):
+        actions.append((f"refl{k}", tuple((k - d) % 6 for d in range(6))))
+    return actions
+
+
+def board_automorphisms(board: Board) -> list[Automorphism]:
+    """Return every automorphism of the directed board graph.
+
+    Each is ``(action_name, direction_permutation, cell_permutation)``, one per
+    distinct cell permutation. The identity is always included.
+    """
+    n = board.n_cells
+    nb = [board.neighbours(c) for c in range(n)]
+    found: dict[tuple[int, ...], Automorphism] = {}
+
+    for name, rho in _dihedral_direction_actions():
+        # rho fixes the direction action; try every image of an anchor cell and
+        # propagate pi across the (connected) board, checking consistency.
+        for image in range(n):
+            pi: dict[int, int] = {0: image}
+            stack = [0]
+            ok = True
+            while stack and ok:
+                u = stack.pop()
+                pu = pi[u]
+                for d in range(6):
+                    v, w = nb[u][d], nb[pu][rho[d]]
+                    if (v == OFF_BOARD) != (w == OFF_BOARD):
+                        ok = False
+                        break
+                    if v == OFF_BOARD:
+                        continue
+                    if v in pi:
+                        if pi[v] != w:
+                            ok = False
+                            break
+                    else:
+                        pi[v] = w
+                        stack.append(v)
+            if ok and len(pi) == n and len(set(pi.values())) == n:
+                key = tuple(pi[c] for c in range(n))
+                found.setdefault(key, (name, rho, pi))
+
+    return list(found.values())
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Board automorphism group.")
+    parser.add_argument("n_cols", type=int, nargs="?", default=5)
+    parser.add_argument("n_rows", type=int, nargs="?", default=5)
+    args = parser.parse_args(argv)
+
+    board = Board(args.n_cols, args.n_rows)
+    autos = board_automorphisms(board)
+
+    print(f"|Aut| ({board.n_cols}x{board.n_rows} directed graph) = {len(autos)}\n")
+    for name, rho, pi in autos:
+        moved = [c for c in range(board.n_cells) if pi[c] != c]
+        dirs = " ".join(
+            f"{DIRECTION_NAMES[d]}->{DIRECTION_NAMES[rho[d]]}" for d in range(6)
+        )
+        if not moved:
+            print(f"[{name}] identity")
+        else:
+            swaps = ", ".join(
+                f"{board.cell_name(c)}->{board.cell_name(pi[c])}" for c in moved
+            )
+            fixed = [board.cell_name(c) for c in board.cells if pi[c] == c]
+            print(f"[{name}] mirror — directions: {dirs}")
+            print(f"  fixed: {fixed}")
+            print(f"  swaps: {swaps}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/layer_profile.py
+++ b/scripts/layer_profile.py
@@ -37,12 +37,7 @@ from math import comb
 
 def layer(n_cells: int, d1: int, d2: int, t: int) -> int:
     """Number of configurations with exactly ``t`` cells filled."""
-    return (
-        comb(n_cells, t)
-        * 2**t
-        * comb(d1, (t + 1) // 2)
-        * comb(d2, t // 2)
-    )
+    return comb(n_cells, t) * 2**t * comb(d1, (t + 1) // 2) * comb(d2, t // 2)
 
 
 def profile(n_cells: int, d1: int, d2: int) -> list[int]:
@@ -69,21 +64,24 @@ def report(n_cells: int, d1: int, d2: int, endgame: int) -> None:
         print("  !! hands cannot fill the board -- check the deck sizes")
     print()
 
-    print(f"  {'t':>3} {'ply':>4} {'k empty':>8} {'configurations':>12} "
-          f"{'% total':>8}  profile")
+    print(
+        f"  {'t':>3} {'ply':>4} {'k empty':>8} {'configurations':>12} "
+        f"{'% total':>8}  profile"
+    )
     print("  " + "-" * 62)
     widest = counts[peak]
     for t, c in enumerate(counts):
         share = 100 * c / total
         bar = "#" * round(40 * c / widest)
         mark = "  <== peak" if t == peak else ""
-        print(f"  {t:>3} {t:>4} {n_cells - t:>8} {sci(c)} {share:>7.2f}%  "
-              f"{bar}{mark}")
+        print(f"  {t:>3} {t:>4} {n_cells - t:>8} {sci(c)} {share:>7.2f}%  {bar}{mark}")
 
     print()
     print(f"  total ................ {total:.4g}")
-    print(f"  peak layer ........... t = {peak} ({counts[peak]:.4g}, "
-          f"{100 * counts[peak] / total:.1f}% of all states)")
+    print(
+        f"  peak layer ........... t = {peak} ({counts[peak]:.4g}, "
+        f"{100 * counts[peak] / total:.1f}% of all states)"
+    )
     print(f"  terminal layer t = {n_cells} .. {counts[-1]:,}")
     print("      (all cells filled, both hands exhausted -- decided by counting")
     print("       cells, so it is verifiable in closed form: adr-010 V0)")

--- a/scripts/layer_profile.py
+++ b/scripts/layer_profile.py
@@ -1,0 +1,132 @@
+"""Tabulate the state-space bound layer by layer.
+
+The reachable-state bound of `adr-003 <../docs/adr/adr-003-piece-representation.md>`_
+is a sum over the number of filled cells ``t``::
+
+    S = sum_t  C(N, t) * 2^t * C(d1, ceil(t/2)) * C(d2, floor(t/2))
+
+for a board of ``N`` cells and decks of ``d1`` (Player 1, moves on odd plies) and
+``d2`` (Player 2) tiles. This script evaluates the summand rather than only the
+total, which is what makes it useful:
+
+* the **shape** of the profile decides whether the game converges (a funnel, as
+  in checkers) or not (a hump, as in FLIPHEX) -- ``exercises/ex02`` Q6(c);
+* the **terminal layer** is the closed-form base case of the retrograde sweep,
+  and is small enough to verify exhaustively -- ``adr-010`` V0;
+* the **endgame slices** size the retrograde databases -- ``adr-004`` part 3.
+
+Everything here is closed form. Nothing imports ``fliphex``: that is deliberate.
+``adr-010`` V1 compares this formula against what the solver's enumerator
+actually produces, and a comparison is only evidence if the two sides are
+computed by genuinely different means. Keep this file free of engine imports.
+
+Note the bound counts *configurations consistent with the invariants*, not
+positions reachable by legal play, so it is an upper bound. Measuring the gap is
+V1's other job.
+
+    python scripts/layer_profile.py                  # shipped 5x5, full deck
+    python scripts/layer_profile.py --cells 16 --hands 8 8    # 4x4, adr-009 deck
+    python scripts/layer_profile.py --cells 9                 # 3x3, full deck
+"""
+
+from __future__ import annotations
+
+import argparse
+from math import comb
+
+
+def layer(n_cells: int, d1: int, d2: int, t: int) -> int:
+    """Number of configurations with exactly ``t`` cells filled."""
+    return (
+        comb(n_cells, t)
+        * 2**t
+        * comb(d1, (t + 1) // 2)
+        * comb(d2, t // 2)
+    )
+
+
+def profile(n_cells: int, d1: int, d2: int) -> list[int]:
+    return [layer(n_cells, d1, d2, t) for t in range(n_cells + 1)]
+
+
+def sci(x: int | float) -> str:
+    """Render as a mantissa/exponent string, or plainly when small."""
+    if x == 0:
+        return "0"
+    if x < 10_000:
+        return f"{x:>9,}"
+    return f"{x:>9.3g}"
+
+
+def report(n_cells: int, d1: int, d2: int, endgame: int) -> None:
+    counts = profile(n_cells, d1, d2)
+    total = sum(counts)
+    peak = max(range(len(counts)), key=counts.__getitem__)
+
+    print(f"Board: {n_cells} cells   hands: {d1} (P1, odd plies) + {d2} (P2)")
+    print(f"Plies: {n_cells}   ({d1} + {d2} = {d1 + d2} tiles available)")
+    if d1 + d2 < n_cells:
+        print("  !! hands cannot fill the board -- check the deck sizes")
+    print()
+
+    print(f"  {'t':>3} {'ply':>4} {'k empty':>8} {'configurations':>12} "
+          f"{'% total':>8}  profile")
+    print("  " + "-" * 62)
+    widest = counts[peak]
+    for t, c in enumerate(counts):
+        share = 100 * c / total
+        bar = "#" * round(40 * c / widest)
+        mark = "  <== peak" if t == peak else ""
+        print(f"  {t:>3} {t:>4} {n_cells - t:>8} {sci(c)} {share:>7.2f}%  "
+              f"{bar}{mark}")
+
+    print()
+    print(f"  total ................ {total:.4g}")
+    print(f"  peak layer ........... t = {peak} ({counts[peak]:.4g}, "
+          f"{100 * counts[peak] / total:.1f}% of all states)")
+    print(f"  terminal layer t = {n_cells} .. {counts[-1]:,}")
+    print("      (all cells filled, both hands exhausted -- decided by counting")
+    print("       cells, so it is verifiable in closed form: adr-010 V0)")
+
+    print()
+    print("  endgame slices (k = empty cells, i.e. the last k plies):")
+    cum = 0
+    for k in range(0, min(endgame, n_cells) + 1):
+        cum += counts[n_cells - k]
+        print(f"    k <= {k} ............... {cum:.4g}")
+
+    shape = "hump" if 0 < peak < n_cells else "monotone"
+    print()
+    print(f"  shape: {shape}. ", end="")
+    if shape == "hump":
+        print("The widest part of the state space is the MIDDLE, not")
+        print("  the endgame -- so there is no convergence to exploit, and")
+        print("  meeting in the middle is the worst available meeting point.")
+    else:
+        print("Monotone profile.")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--cells", type=int, default=25, help="board cells (default 25)")
+    p.add_argument(
+        "--hands",
+        type=int,
+        nargs=2,
+        metavar=("D1", "D2"),
+        default=(13, 12),
+        help="deck sizes for P1 and P2 (default 13 12)",
+    )
+    p.add_argument(
+        "--endgame",
+        type=int,
+        default=5,
+        help="largest k to report an endgame slice for (default 5)",
+    )
+    args = p.parse_args()
+    report(args.cells, args.hands[0], args.hands[1], args.endgame)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/show_mirror_break.py
+++ b/scripts/show_mirror_break.py
@@ -27,6 +27,7 @@ from check_mirror_game_symmetry import (  # noqa: E402
     fmt,
     mirror_mask,
     mirror_of,
+    mirror_state,
 )
 
 from fliphex.board import DIRECTION_NAMES, OFF_BOARD, Board  # noqa: E402
@@ -37,6 +38,24 @@ GLYPH = {Colour.EMPTY: "·", Colour.PURPLE: "P", Colour.GREEN: "G"}
 CELL_W = 6
 N_LINES = 10
 
+_ANSI = {"reset": "", "purple": "", "green": "", "empty": "", "mark": ""}
+
+
+def enable_colour(on: bool) -> None:
+    """Turn ANSI colour on or off for the whole renderer."""
+    _ANSI.update(
+        {
+            "reset": "\033[0m" if on else "",
+            "purple": "\033[1;95m" if on else "",  # bright magenta
+            "green": "\033[1;92m" if on else "",  # bright green
+            "empty": "\033[90m" if on else "",  # dim
+            "mark": "\033[1;93m" if on else "",  # yellow, for * and !
+        }
+    )
+
+
+_KEY = {Colour.PURPLE: "purple", Colour.GREEN: "green", Colour.EMPTY: "empty"}
+
 
 # -- rendering ----------------------------------------------------------------
 
@@ -44,32 +63,55 @@ N_LINES = 10
 def render(board: Board, colours, marks: dict[int, str], title: str) -> list[str]:
     """Return the board as text lines, B/D columns offset by half a row.
 
-    ``marks`` overlays one character per cell: ``*`` placed, ``!`` flipped,
-    ``?`` a cell the mirrored arrows would have hit.
+    ``marks`` overlays one character per cell: ``*`` placed, ``!`` flipped.
+    Tokens are padded on their *plain* width, so ANSI codes never disturb the
+    column alignment.
     """
-    grid = [[" "] * (5 * CELL_W) for _ in range(N_LINES)]
+    placed: list[dict[int, str]] = [{} for _ in range(N_LINES)]
     for cid in board.cells:
         name = board.cell_name(cid)
         col = ord(name[0]) - ord("A")
         row = int(name[1])
         line = 2 * (row - 1) + (1 if col % 2 else 0)
-        token = f"{name}{GLYPH[colours[cid]]}{marks.get(cid, ' ')}"
-        for i, ch in enumerate(token):
-            grid[line][col * CELL_W + i] = ch
+        mark = marks.get(cid, " ")
+        body = f"{name}{GLYPH[colours[cid]]}"
+        tail = f"{_ANSI['mark']}{mark}{_ANSI['reset']}" if mark != " " else " "
+        placed[line][col] = f"{_ANSI[_KEY[colours[cid]]]}{body}{_ANSI['reset']}{tail}"
+
+    body_lines = []
+    for row_cells in placed:
+        out = ""
+        for col in range(5):
+            token = row_cells.get(col)
+            out += (token + " " * (CELL_W - 4)) if token else " " * CELL_W
+        body_lines.append(out.rstrip())
 
     header = "".join(f"{chr(ord('A') + c):^{CELL_W}}" for c in range(5))
-    body = ["".join(row).rstrip() for row in grid]
-    return [title, header, *body]
+    return [title, header, *body_lines]
+
+
+def vlen(s: str) -> int:
+    """Visible width, ignoring ANSI escape sequences."""
+    out, i = 0, 0
+    while i < len(s):
+        if s[i] == "\033":
+            while i < len(s) and s[i] != "m":
+                i += 1
+            i += 1
+        else:
+            out += 1
+            i += 1
+    return out
 
 
 def side_by_side(left: list[str], right: list[str], gap: int = 6) -> str:
-    width = max((len(x) for x in left), default=0)
+    width = max((vlen(x) for x in left), default=0)
     n = max(len(left), len(right))
     out = []
     for i in range(n):
-        lhs = (left[i] if i < len(left) else "").ljust(width)
+        lhs = left[i] if i < len(left) else ""
         rhs = right[i] if i < len(right) else ""
-        out.append((lhs + " " * gap + rhs).rstrip())
+        out.append((lhs + " " * (width - vlen(lhs) + gap) + rhs).rstrip())
     return "\n".join(out)
 
 
@@ -96,78 +138,155 @@ def setup(board: Board, cell: int, pattern: int, mover: Colour) -> GameState:
     return GameState.build(tuple(colours), (hand, hand), mover)
 
 
+def _hits(board: Board, cell: int, pattern: int) -> str:
+    return ", ".join(
+        f"{DIRECTION_NAMES[d]}->{board.cell_name(nb)}"
+        for d, nb in arrow_targets(board, cell, pattern)
+    )
+
+
 def show_case(board: Board, pi, rho, archetype: str, rotation: int, cell_name: str) -> None:
+    """Walk one placement through the mirror, step by step.
+
+    Told as a narrative rather than a picture, because the *position* on the
+    right always looks symmetric -- what is missing is the **move**, and a
+    board diagram cannot show a move that does not exist.
+    """
     tile = TILE_INDEX[archetype]
     cell = board.cell_id(cell_name)
     pattern = TILES[tile].rotated(rotation)
-    m_cell = pi[cell]
-    m_pattern = mirror_mask(pattern, rho)
+    m_cell, m_pattern = pi[cell], mirror_mask(pattern, rho)
+    found = find_placement((1 << len(TILES)) - 1, m_pattern)
 
     print("\n" + "=" * 78)
-    print(f"CASE — {archetype} on {cell_name}, rotation {rotation}, arrows {fmt(pattern)}")
+    verdict = "the mirror BREAKS" if found is None else "the mirror HOLDS"
+    kind = "chiral" if found is None else "achiral"
+    print(f"CASE — {archetype} ({kind}): {verdict}")
     print("=" * 78)
 
-    # left: the real position, before and after the flip
+    before = setup(board, cell, pattern, Colour.PURPLE)
+    m_before = mirror_state(before, pi)
+
+    print("\nSTEP 1 — a position, and its mirror. These two ARE mirror images of")
+    print("         each other; nothing is wrong yet.\n")
+    print(side_by_side(
+        render(board, before.colours, {}, "position  s"),
+        render(board, m_before.colours, {}, "mirrored position  M(s)"),
+    ))
+
+    after = apply_move(board, before, Move(cell, tile, rotation))
+    flipped = [c for c in board.cells if before.colours[c] != after.colours[c] and c != cell]
+    print(f"\nSTEP 2 — purple plays {archetype} on {cell_name} (rotation {rotation}).")
+    print(f"         Arrows {fmt(pattern)} fire once: {_hits(board, cell, pattern)}")
+    print(f"         Flipped: {', '.join(board.cell_name(c) for c in flipped)}\n")
+    print("\n".join(render(
+        board, after.colours,
+        {cell: "*", **{c: "!" for c in flipped}}, "after the move",
+    )))
+
+    print("\nSTEP 3 — for the mirror to keep in step, purple must now play the")
+    print(f"         mirrored move: on {board.cell_name(m_cell)} with arrows "
+          f"{fmt(m_pattern)}")
+    print(f"         (which would hit {_hits(board, m_cell, m_pattern)}).")
+    print(f"\n         Is that move available? Every rotation of {archetype}:")
+    for r in TILES[tile].distinct_rotations():
+        got = TILES[tile].rotated(r)
+        flag = "  <== the one needed" if got == m_pattern else ""
+        print(f"           rot {r}: {fmt(got):<24}{flag}")
+
+    if found is None:
+        print(f"\n         >> NONE match {fmt(m_pattern)}, and no other tile in the deck")
+        print(f"            produces it either. {archetype} is CHIRAL: a hex tile can be")
+        print("            rotated but never turned face-down, so its own reflection is")
+        print("            not among the patterns it can present.")
+        print("\n         >> There is NO legal move from M(s) giving the mirrored result.")
+        print("            The position on the right of STEP 1 is fine. The *move* is")
+        print("            what has no mirror image — and that is the whole break.")
+        return
+
+    m_tile, m_rot = found
+    m_after = apply_move(board, m_before, Move(m_cell, m_tile, m_rot))
+    m_flipped = [c for c in board.cells if m_before.colours[c] != m_after.colours[c]
+                 and c != m_cell]
+    same = TILES[m_tile].archetype == archetype
+    note = ("same archetype, rotated" if same and m_rot != rotation
+            else "same archetype, same rotation — mirror-invariant" if same
+            else f"a different archetype, {TILES[m_tile].archetype}")
+    print(f"\n         >> YES: rotation {m_rot} ({note}). Purple plays it on "
+          f"{board.cell_name(m_cell)}.\n")
+    print("\n".join(render(
+        board, m_after.colours,
+        {m_cell: "*", **{c: "!" for c in m_flipped}}, "mirrored board after the mirrored move",
+    )))
+    assert mirror_state(after, pi).colours == m_after.colours
+    print("\n         >> And this equals M(result of STEP 2), checked exactly.")
+    print("            Both the position and the move mirror. Symmetry holds.")
+
+
+def show_inertness(board: Board) -> None:
+    """Demonstrate adr-003/adr-006: a placed tile is a colour, nothing more.
+
+    The ``*`` in the diagrams above is *presentation only* — it is taken from
+    the move we just applied, not read back from the state. Once placed, a tile
+    keeps no arrows, no rotation and no identity.
+    """
+    print("\n" + "=" * 78)
+    print("ASIDE — a placed tile keeps no arrows (adr-003, adr-006)")
+    print("=" * 78)
+
+    tile, rotation, cell = TILE_INDEX["P3-y"], 0, board.cell_id("B2")
+    pattern = TILES[tile].rotated(rotation)
     state = setup(board, cell, pattern, Colour.PURPLE)
     after = apply_move(board, state, Move(cell, tile, rotation))
-    flipped = {c for c in board.cells if state.colours[c] != after.colours[c] and c != cell}
-    marks = {cell: "*", **{c: "!" for c in flipped}}
-    left = render(board, after.colours, marks, f"original — play {archetype} on {cell_name}")
 
-    # right: the mirror. Can any tile in a full deck produce the mirrored pattern?
-    found = find_placement((1 << len(TILES)) - 1, m_pattern)
-    m_colours = [Colour.EMPTY] * board.n_cells
-    for c in board.cells:
-        m_colours[pi[c]] = after.colours[c]
-    m_marks = {pi[c]: mk for c, mk in marks.items()}
+    print("  after playing P3-y on B2, this is *everything* the state records for B2:")
+    print(f"      colours[B2] = {after.colours[cell].name}")
+    print("  there is no tile field and no rotation field — see fliphex/state.py.")
+    print("  P3-y is now gone from the hand and B2 is a purple cell like any other.\n")
 
-    if found is None:
-        title = f"mirror — needs {fmt(m_pattern)} on {board.cell_name(m_cell)}: IMPOSSIBLE"
-        right = render(board, tuple(m_colours), m_marks, title)
-    else:
-        m_tile, m_rot = found
-        title = (
-            f"mirror — play {TILES[m_tile].archetype} on "
-            f"{board.cell_name(m_cell)}, rotation {m_rot}"
-        )
-        right = render(board, tuple(m_colours), m_marks, title)
+    # Green replies next to it with a tile whose arrow points back at B2.
+    # If B2 still had arrows, they would re-fire. They do not.
+    reply_cell = board.cell_id("B3")
+    back = next(d for d in range(6) if board.neighbour(reply_cell, d) == cell)
+    reply_tile = TILE_INDEX["P1"]
+    reply_rot = next(
+        r for r in TILES[reply_tile].distinct_rotations()
+        if TILES[reply_tile].rotated(r) == 1 << back
+    )
+    final = apply_move(board, after, Move(reply_cell, reply_tile, reply_rot))
 
+    changed = [board.cell_name(c) for c in board.cells if after.colours[c] != final.colours[c]]
+    print("  NOTE: the two boards below are NOT a mirror pair — they are the SAME")
+    print("        board, one ply apart. Only one tile is ever played per cell.\n")
+    left = render(board, after.colours, {cell: "*"}, "ply n   — purple has just played B2")
+    right = render(
+        board, final.colours, {reply_cell: "*", cell: "!"},
+        f"ply n+1 — green plays B3, arrow {DIRECTION_NAMES[back]} flips B2",
+    )
     print(side_by_side(left, right))
-
-    dirs = ", ".join(f"{DIRECTION_NAMES[d]}->{board.cell_name(nb)}" for d, nb in
-                     arrow_targets(board, cell, pattern))
-    m_dirs = ", ".join(f"{DIRECTION_NAMES[d]}->{board.cell_name(nb)}" for d, nb in
-                       arrow_targets(board, m_cell, m_pattern))
-    print(f"\n  arrows hit : {dirs}")
-    print(f"  mirror hits: {m_dirs}")
-    if found is None:
-        print(f"\n  >> The mirror needs {fmt(m_pattern)}. Every rotation of {archetype}:")
-        for r in TILES[tile].distinct_rotations():
-            got = TILES[tile].rotated(r)
-            print(f"       rot {r}: {fmt(got):<22} {'== needed' if got == m_pattern else '!='}")
-        print(f"     None match, and no other tile in the deck does either. {archetype} is")
-        print("     CHIRAL — a hex tile can be rotated but never turned over, so its own")
-        print("     reflection is simply not one of the patterns it can present.")
-        print("     The right-hand board is a position no legal move can reach.")
-    else:
-        m_tile, m_rot = found
-        same = TILES[m_tile].archetype == archetype
-        how = " (same archetype, rotated)" if same and m_rot != rotation else (
-            " (same archetype, same rotation — mirror-invariant)" if same else "")
-        print(f"\n  >> Mirrored by {TILES[m_tile].archetype} at rotation {m_rot}{how}."
-              " Symmetry holds.")
+    print(f"\n  cells that changed between the two: {', '.join(changed)}")
+    print("  B2 did not receive a second tile. It was purple; green's single arrow")
+    print("  flipped it, so it now reads G. That is the flip rule, not a placement.")
+    print("\n  The point: B2's OWN arrows {N,NE,S} did not re-fire when it flipped —")
+    print("  B1 and C2 are untouched. Once placed, a tile is only a colour: no")
+    print("  arrows, no rotation, no identity (adr-003), and flips never chain")
+    print("  (adr-006). The '*' in these diagrams is drawn from the move we just")
+    print("  applied; the state itself does not record where anything was placed.")
 
 
 def main() -> int:
     board = Board()
+    enable_colour(sys.stdout.isatty() or "--color" in sys.argv)
     pi, rho = mirror_of(board)
 
     print("Legend:  · empty   P purple   G green   * tile placed   ! flipped by an arrow")
     print("Columns B and D are drawn half a row lower — the board's real geometry.")
+    print("(pipe the output somewhere? pass --color to keep the colours)")
 
     show_case(board, pi, rho, "P3-y", 0, "B2")      # the break
     show_case(board, pi, rho, "P2-adj", 0, "B2")    # control: achiral, mirrors fine
     show_case(board, pi, rho, "P3-tri", 0, "B2")    # control: mirror-invariant
+    show_inertness(board)
 
     print("\n" + "=" * 78)
     print("Only P3-y fails. Once both copies are placed and inert, every remaining")

--- a/scripts/show_mirror_break.py
+++ b/scripts/show_mirror_break.py
@@ -171,10 +171,12 @@ def show_case(
 
     print("\nSTEP 1 — a position, and its mirror. These two ARE mirror images of")
     print("         each other; nothing is wrong yet.\n")
-    print(side_by_side(
-        render(board, before.colours, {}, "position  s"),
-        render(board, m_before.colours, {}, "mirrored position  M(s)"),
-    ))
+    print(
+        side_by_side(
+            render(board, before.colours, {}, "position  s"),
+            render(board, m_before.colours, {}, "mirrored position  M(s)"),
+        )
+    )
 
     after = apply_move(board, before, Move(cell, tile, rotation))
     flipped = [
@@ -183,14 +185,22 @@ def show_case(
     print(f"\nSTEP 2 — purple plays {archetype} on {cell_name} (rotation {rotation}).")
     print(f"         Arrows {fmt(pattern)} fire once: {_hits(board, cell, pattern)}")
     print(f"         Flipped: {', '.join(board.cell_name(c) for c in flipped)}\n")
-    print("\n".join(render(
-        board, after.colours,
-        {cell: "*", **{c: "!" for c in flipped}}, "after the move",
-    )))
+    print(
+        "\n".join(
+            render(
+                board,
+                after.colours,
+                {cell: "*", **{c: "!" for c in flipped}},
+                "after the move",
+            )
+        )
+    )
 
     print("\nSTEP 3 — for the mirror to keep in step, purple must now play the")
-    print(f"         mirrored move: on {board.cell_name(m_cell)} with arrows "
-          f"{fmt(m_pattern)}")
+    print(
+        f"         mirrored move: on {board.cell_name(m_cell)} with arrows "
+        f"{fmt(m_pattern)}"
+    )
     print(f"         (which would hit {_hits(board, m_cell, m_pattern)}).")
     print(f"\n         Is that move available? Every rotation of {archetype}:")
     for r in TILES[tile].distinct_rotations():
@@ -210,19 +220,33 @@ def show_case(
 
     m_tile, m_rot = found
     m_after = apply_move(board, m_before, Move(m_cell, m_tile, m_rot))
-    m_flipped = [c for c in board.cells if m_before.colours[c] != m_after.colours[c]
-                 and c != m_cell]
+    m_flipped = [
+        c
+        for c in board.cells
+        if m_before.colours[c] != m_after.colours[c] and c != m_cell
+    ]
     same = TILES[m_tile].archetype == archetype
-    note = ("same archetype, rotated" if same and m_rot != rotation
-            else "same archetype, same rotation — mirror-invariant" if same
-            else f"a different archetype, {TILES[m_tile].archetype}")
-    print(f"\n         >> YES: rotation {m_rot} ({note}). Purple plays it on "
-          f"{board.cell_name(m_cell)}.\n")
-    print("\n".join(render(
-        board, m_after.colours,
-        {m_cell: "*", **{c: "!" for c in m_flipped}},
-        "mirrored board after the mirrored move",
-    )))
+    note = (
+        "same archetype, rotated"
+        if same and m_rot != rotation
+        else "same archetype, same rotation — mirror-invariant"
+        if same
+        else f"a different archetype, {TILES[m_tile].archetype}"
+    )
+    print(
+        f"\n         >> YES: rotation {m_rot} ({note}). Purple plays it on "
+        f"{board.cell_name(m_cell)}.\n"
+    )
+    print(
+        "\n".join(
+            render(
+                board,
+                m_after.colours,
+                {m_cell: "*", **{c: "!" for c in m_flipped}},
+                "mirrored board after the mirrored move",
+            )
+        )
+    )
     assert mirror_state(after, pi).colours == m_after.colours
     print("\n         >> And this equals M(result of STEP 2), checked exactly.")
     print("            Both the position and the move mirror. Symmetry holds.")
@@ -255,15 +279,14 @@ def show_inertness(board: Board) -> None:
     back = next(d for d in range(6) if board.neighbour(reply_cell, d) == cell)
     reply_tile = TILE_INDEX["P1"]
     reply_rot = next(
-        r for r in TILES[reply_tile].distinct_rotations()
+        r
+        for r in TILES[reply_tile].distinct_rotations()
         if TILES[reply_tile].rotated(r) == 1 << back
     )
     final = apply_move(board, after, Move(reply_cell, reply_tile, reply_rot))
 
     changed = [
-        board.cell_name(c)
-        for c in board.cells
-        if after.colours[c] != final.colours[c]
+        board.cell_name(c) for c in board.cells if after.colours[c] != final.colours[c]
     ]
     print("  NOTE: the two boards below are NOT a mirror pair — they are the SAME")
     print("        board, one ply apart. Only one tile is ever played per cell.\n")
@@ -271,7 +294,9 @@ def show_inertness(board: Board) -> None:
         board, after.colours, {cell: "*"}, "ply n   — purple has just played B2"
     )
     right = render(
-        board, final.colours, {reply_cell: "*", cell: "!"},
+        board,
+        final.colours,
+        {reply_cell: "*", cell: "!"},
         f"ply n+1 — green plays B3, arrow {DIRECTION_NAMES[back]} flips B2",
     )
     print(side_by_side(left, right))
@@ -294,9 +319,9 @@ def main() -> int:
     print("Columns B and D are drawn half a row lower — the board's real geometry.")
     print("(pipe the output somewhere? pass --color to keep the colours)")
 
-    show_case(board, pi, rho, "P3-y", 0, "B2")      # the break
-    show_case(board, pi, rho, "P2-adj", 0, "B2")    # control: achiral, mirrors fine
-    show_case(board, pi, rho, "P3-tri", 0, "B2")    # control: mirror-invariant
+    show_case(board, pi, rho, "P3-y", 0, "B2")  # the break
+    show_case(board, pi, rho, "P2-adj", 0, "B2")  # control: achiral, mirrors fine
+    show_case(board, pi, rho, "P3-tri", 0, "B2")  # control: mirror-invariant
     show_inertness(board)
 
     print("\n" + "=" * 78)

--- a/scripts/show_mirror_break.py
+++ b/scripts/show_mirror_break.py
@@ -145,7 +145,9 @@ def _hits(board: Board, cell: int, pattern: int) -> str:
     )
 
 
-def show_case(board: Board, pi, rho, archetype: str, rotation: int, cell_name: str) -> None:
+def show_case(
+    board: Board, pi, rho, archetype: str, rotation: int, cell_name: str
+) -> None:
     """Walk one placement through the mirror, step by step.
 
     Told as a narrative rather than a picture, because the *position* on the
@@ -175,7 +177,9 @@ def show_case(board: Board, pi, rho, archetype: str, rotation: int, cell_name: s
     ))
 
     after = apply_move(board, before, Move(cell, tile, rotation))
-    flipped = [c for c in board.cells if before.colours[c] != after.colours[c] and c != cell]
+    flipped = [
+        c for c in board.cells if before.colours[c] != after.colours[c] and c != cell
+    ]
     print(f"\nSTEP 2 — purple plays {archetype} on {cell_name} (rotation {rotation}).")
     print(f"         Arrows {fmt(pattern)} fire once: {_hits(board, cell, pattern)}")
     print(f"         Flipped: {', '.join(board.cell_name(c) for c in flipped)}\n")
@@ -195,11 +199,11 @@ def show_case(board: Board, pi, rho, archetype: str, rotation: int, cell_name: s
         print(f"           rot {r}: {fmt(got):<24}{flag}")
 
     if found is None:
-        print(f"\n         >> NONE match {fmt(m_pattern)}, and no other tile in the deck")
-        print(f"            produces it either. {archetype} is CHIRAL: a hex tile can be")
-        print("            rotated but never turned face-down, so its own reflection is")
-        print("            not among the patterns it can present.")
-        print("\n         >> There is NO legal move from M(s) giving the mirrored result.")
+        print(f"\n         >> NONE match {fmt(m_pattern)}, and no other tile in the")
+        print(f"            deck produces it either. {archetype} is CHIRAL: a hex tile")
+        print("            can be rotated but never turned face-down, so its own")
+        print("            reflection is not among the patterns it can present.")
+        print("\n         >> There is NO legal move from M(s) giving that result.")
         print("            The position on the right of STEP 1 is fine. The *move* is")
         print("            what has no mirror image — and that is the whole break.")
         return
@@ -216,7 +220,8 @@ def show_case(board: Board, pi, rho, archetype: str, rotation: int, cell_name: s
           f"{board.cell_name(m_cell)}.\n")
     print("\n".join(render(
         board, m_after.colours,
-        {m_cell: "*", **{c: "!" for c in m_flipped}}, "mirrored board after the mirrored move",
+        {m_cell: "*", **{c: "!" for c in m_flipped}},
+        "mirrored board after the mirrored move",
     )))
     assert mirror_state(after, pi).colours == m_after.colours
     print("\n         >> And this equals M(result of STEP 2), checked exactly.")
@@ -255,10 +260,16 @@ def show_inertness(board: Board) -> None:
     )
     final = apply_move(board, after, Move(reply_cell, reply_tile, reply_rot))
 
-    changed = [board.cell_name(c) for c in board.cells if after.colours[c] != final.colours[c]]
+    changed = [
+        board.cell_name(c)
+        for c in board.cells
+        if after.colours[c] != final.colours[c]
+    ]
     print("  NOTE: the two boards below are NOT a mirror pair — they are the SAME")
     print("        board, one ply apart. Only one tile is ever played per cell.\n")
-    left = render(board, after.colours, {cell: "*"}, "ply n   — purple has just played B2")
+    left = render(
+        board, after.colours, {cell: "*"}, "ply n   — purple has just played B2"
+    )
     right = render(
         board, final.colours, {reply_cell: "*", cell: "!"},
         f"ply n+1 — green plays B3, arrow {DIRECTION_NAMES[back]} flips B2",
@@ -279,7 +290,7 @@ def main() -> int:
     enable_colour(sys.stdout.isatty() or "--color" in sys.argv)
     pi, rho = mirror_of(board)
 
-    print("Legend:  · empty   P purple   G green   * tile placed   ! flipped by an arrow")
+    print("Legend:  · empty   P purple   G green   * tile placed   ! flipped")
     print("Columns B and D are drawn half a row lower — the board's real geometry.")
     print("(pipe the output somewhere? pass --color to keep the colours)")
 

--- a/scripts/show_mirror_break.py
+++ b/scripts/show_mirror_break.py
@@ -1,0 +1,181 @@
+"""Draw, side by side, a position and its mirror image -- and where it breaks.
+
+Companion to ``scripts/check_mirror_game_symmetry.py``, which *proves* that the
+board's Z/2 mirror is only a partial game symmetry. This one *shows* it.
+
+Each case places one tile, fires its arrows, and then asks the same question of
+the mirrored board: is there a tile in the deck that produces the mirrored
+arrow pattern on the mirrored cell? For every achiral tile the answer is yes
+(the same archetype, a different rotation). For the chiral ``P3-y`` it is no,
+and the right-hand board simply cannot be drawn.
+
+    python scripts/show_mirror_break.py
+
+Boards are flat-top hexagons in five vertical columns of five; columns B and D
+sit half a cell lower than A, C and E, which is why they are drawn offset.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_mirror_game_symmetry import (  # noqa: E402
+    find_placement,
+    fmt,
+    mirror_mask,
+    mirror_of,
+)
+
+from fliphex.board import DIRECTION_NAMES, OFF_BOARD, Board  # noqa: E402
+from fliphex.moves import Move, apply_move  # noqa: E402
+from fliphex.state import TILE_INDEX, TILES, Colour, GameState  # noqa: E402
+
+GLYPH = {Colour.EMPTY: "·", Colour.PURPLE: "P", Colour.GREEN: "G"}
+CELL_W = 6
+N_LINES = 10
+
+
+# -- rendering ----------------------------------------------------------------
+
+
+def render(board: Board, colours, marks: dict[int, str], title: str) -> list[str]:
+    """Return the board as text lines, B/D columns offset by half a row.
+
+    ``marks`` overlays one character per cell: ``*`` placed, ``!`` flipped,
+    ``?`` a cell the mirrored arrows would have hit.
+    """
+    grid = [[" "] * (5 * CELL_W) for _ in range(N_LINES)]
+    for cid in board.cells:
+        name = board.cell_name(cid)
+        col = ord(name[0]) - ord("A")
+        row = int(name[1])
+        line = 2 * (row - 1) + (1 if col % 2 else 0)
+        token = f"{name}{GLYPH[colours[cid]]}{marks.get(cid, ' ')}"
+        for i, ch in enumerate(token):
+            grid[line][col * CELL_W + i] = ch
+
+    header = "".join(f"{chr(ord('A') + c):^{CELL_W}}" for c in range(5))
+    body = ["".join(row).rstrip() for row in grid]
+    return [title, header, *body]
+
+
+def side_by_side(left: list[str], right: list[str], gap: int = 6) -> str:
+    width = max((len(x) for x in left), default=0)
+    n = max(len(left), len(right))
+    out = []
+    for i in range(n):
+        lhs = (left[i] if i < len(left) else "").ljust(width)
+        rhs = right[i] if i < len(right) else ""
+        out.append((lhs + " " * gap + rhs).rstrip())
+    return "\n".join(out)
+
+
+# -- one case -----------------------------------------------------------------
+
+
+def arrow_targets(board: Board, cell: int, pattern: int) -> list[tuple[int, int]]:
+    """Return ``(direction, neighbour)`` for each arrow that lands on the board."""
+    hits = []
+    for d in range(6):
+        if pattern >> d & 1:
+            nb = board.neighbour(cell, d)
+            if nb != OFF_BOARD:
+                hits.append((d, nb))
+    return hits
+
+
+def setup(board: Board, cell: int, pattern: int, mover: Colour) -> GameState:
+    """A position where every arrow of ``pattern`` has an enemy tile to flip."""
+    colours = [Colour.EMPTY] * board.n_cells
+    for _d, nb in arrow_targets(board, cell, pattern):
+        colours[nb] = Colour.GREEN if mover == Colour.PURPLE else Colour.PURPLE
+    hand = (1 << len(TILES)) - 1
+    return GameState.build(tuple(colours), (hand, hand), mover)
+
+
+def show_case(board: Board, pi, rho, archetype: str, rotation: int, cell_name: str) -> None:
+    tile = TILE_INDEX[archetype]
+    cell = board.cell_id(cell_name)
+    pattern = TILES[tile].rotated(rotation)
+    m_cell = pi[cell]
+    m_pattern = mirror_mask(pattern, rho)
+
+    print("\n" + "=" * 78)
+    print(f"CASE — {archetype} on {cell_name}, rotation {rotation}, arrows {fmt(pattern)}")
+    print("=" * 78)
+
+    # left: the real position, before and after the flip
+    state = setup(board, cell, pattern, Colour.PURPLE)
+    after = apply_move(board, state, Move(cell, tile, rotation))
+    flipped = {c for c in board.cells if state.colours[c] != after.colours[c] and c != cell}
+    marks = {cell: "*", **{c: "!" for c in flipped}}
+    left = render(board, after.colours, marks, f"original — play {archetype} on {cell_name}")
+
+    # right: the mirror. Can any tile in a full deck produce the mirrored pattern?
+    found = find_placement((1 << len(TILES)) - 1, m_pattern)
+    m_colours = [Colour.EMPTY] * board.n_cells
+    for c in board.cells:
+        m_colours[pi[c]] = after.colours[c]
+    m_marks = {pi[c]: mk for c, mk in marks.items()}
+
+    if found is None:
+        title = f"mirror — needs {fmt(m_pattern)} on {board.cell_name(m_cell)}: IMPOSSIBLE"
+        right = render(board, tuple(m_colours), m_marks, title)
+    else:
+        m_tile, m_rot = found
+        title = (
+            f"mirror — play {TILES[m_tile].archetype} on "
+            f"{board.cell_name(m_cell)}, rotation {m_rot}"
+        )
+        right = render(board, tuple(m_colours), m_marks, title)
+
+    print(side_by_side(left, right))
+
+    dirs = ", ".join(f"{DIRECTION_NAMES[d]}->{board.cell_name(nb)}" for d, nb in
+                     arrow_targets(board, cell, pattern))
+    m_dirs = ", ".join(f"{DIRECTION_NAMES[d]}->{board.cell_name(nb)}" for d, nb in
+                       arrow_targets(board, m_cell, m_pattern))
+    print(f"\n  arrows hit : {dirs}")
+    print(f"  mirror hits: {m_dirs}")
+    if found is None:
+        print(f"\n  >> The mirror needs {fmt(m_pattern)}. Every rotation of {archetype}:")
+        for r in TILES[tile].distinct_rotations():
+            got = TILES[tile].rotated(r)
+            print(f"       rot {r}: {fmt(got):<22} {'== needed' if got == m_pattern else '!='}")
+        print(f"     None match, and no other tile in the deck does either. {archetype} is")
+        print("     CHIRAL — a hex tile can be rotated but never turned over, so its own")
+        print("     reflection is simply not one of the patterns it can present.")
+        print("     The right-hand board is a position no legal move can reach.")
+    else:
+        m_tile, m_rot = found
+        same = TILES[m_tile].archetype == archetype
+        how = " (same archetype, rotated)" if same and m_rot != rotation else (
+            " (same archetype, same rotation — mirror-invariant)" if same else "")
+        print(f"\n  >> Mirrored by {TILES[m_tile].archetype} at rotation {m_rot}{how}."
+              " Symmetry holds.")
+
+
+def main() -> int:
+    board = Board()
+    pi, rho = mirror_of(board)
+
+    print("Legend:  · empty   P purple   G green   * tile placed   ! flipped by an arrow")
+    print("Columns B and D are drawn half a row lower — the board's real geometry.")
+
+    show_case(board, pi, rho, "P3-y", 0, "B2")      # the break
+    show_case(board, pi, rho, "P2-adj", 0, "B2")    # control: achiral, mirrors fine
+    show_case(board, pi, rho, "P3-tri", 0, "B2")    # control: mirror-invariant
+
+    print("\n" + "=" * 78)
+    print("Only P3-y fails. Once both copies are placed and inert, every remaining")
+    print("move mirrors, and the Z/2 symmetry is fully available — which is exactly")
+    print("the endgame region the retrograde databases cover (adr-008).")
+    print("=" * 78)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -14,9 +14,7 @@ def _automorphisms(board: Board):
     """Return ``(all_autos, non_identity)`` where non_identity is [(rho, pi)]."""
     autos = board_automorphisms(board)
     non_identity = [
-        (rho, pi)
-        for _name, rho, pi in autos
-        if any(pi[c] != c for c in board.cells)
+        (rho, pi) for _name, rho, pi in autos if any(pi[c] != c for c in board.cells)
     ]
     return autos, non_identity
 

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -1,0 +1,71 @@
+"""The board's automorphism group is Z/2 — a left-right mirror (adr-008).
+
+This pins down the correction to the Phase 0 "trivial symmetry group" claim:
+the directed board graph has exactly one non-trivial symmetry, the mirror across
+the central column, and 180-degree rotation is *not* a symmetry.
+"""
+
+from check_symmetry import board_automorphisms
+
+from fliphex.board import Board
+
+
+def _automorphisms(board: Board):
+    """Return ``(all_autos, non_identity)`` where non_identity is [(rho, pi)]."""
+    autos = board_automorphisms(board)
+    non_identity = [
+        (rho, pi)
+        for _name, rho, pi in autos
+        if any(pi[c] != c for c in board.cells)
+    ]
+    return autos, non_identity
+
+
+def test_full_board_group_is_order_two():
+    autos, non_identity = _automorphisms(Board())
+    assert len(autos) == 2
+    assert len(non_identity) == 1
+
+
+def test_mirror_swaps_a_e_and_b_d_fixing_c():
+    board = Board()
+    _autos, non_identity = _automorphisms(board)
+    _rho, pi = non_identity[0]
+
+    def maps(a: str, b: str) -> bool:
+        return pi[board.cell_id(a)] == board.cell_id(b)
+
+    # A <-> E, B <-> D, column C fixed.
+    for row in range(1, 6):
+        assert maps(f"A{row}", f"E{row}")
+        assert maps(f"B{row}", f"D{row}")
+        assert maps(f"C{row}", f"C{row}")
+
+
+def test_mirror_reflects_east_west_directions():
+    # The induced direction action is the vertical mirror of a flat-top hex:
+    # N,S fixed; NE<->NW, SE<->SW.
+    _autos, non_identity = _automorphisms(Board())
+    rho, _pi = non_identity[0]
+    n, ne, se, s, sw, nw = range(6)
+    assert rho[n] == n and rho[s] == s
+    assert rho[ne] == nw and rho[nw] == ne
+    assert rho[se] == sw and rho[sw] == se
+
+
+def test_180_degree_rotation_is_not_a_symmetry():
+    # A 180-degree rotation would be an involution with no fixed cell (25 is
+    # odd, so it cannot exist). The sole non-trivial symmetry fixes column C,
+    # so it is the mirror, not a rotation.
+    board = Board()
+    _autos, non_identity = _automorphisms(board)
+    _rho, pi = non_identity[0]
+    fixed = [c for c in board.cells if pi[c] == c]
+    assert fixed  # non-empty => mirror, not a half-turn
+
+
+def test_reduced_3x3_also_has_the_mirror():
+    # The solver's 3x3 variant (Phase 3) inherits the same Z/2 mirror.
+    autos, non_identity = _automorphisms(Board(3, 3))
+    assert len(autos) == 2
+    assert len(non_identity) == 1

--- a/tils/til-01-perfect-vs-imperfect-information.md
+++ b/tils/til-01-perfect-vs-imperfect-information.md
@@ -1,0 +1,98 @@
+# TIL #1 — Perfect vs imperfect information: what changes when you can see everything
+
+> **Draft.** Written at the close of Phase 2. Voice and examples still to be
+> tightened before publishing.
+
+Hiding information from a player does not make a game imperfect-information. I
+learned this by proposing a variant of my own game that turned out not to be a
+variant at all.
+
+## The setup
+
+FLIPHEX is a two-player game I designed as a student: 25 hexagonal cells, tiles
+carrying arrows that flip adjacent pieces when placed. It is
+**perfect-information** — the rulebook is explicit that both hands, every placed
+tile, its orientation and the joker's colour are public at all times.
+
+That felt like a limitation. Most of my previous work was on a Pokémon TCG agent,
+where the whole difficulty is not knowing what the opponent holds. So the obvious
+enrichment came up: what if the hands were hidden? Same board, same arrows, but
+you cannot see what your opponent still has to play. That sounds like it should
+turn a solved-in-principle game into something much richer.
+
+It doesn't, and working out why is the actual lesson.
+
+## Why the hidden-hand variant is not imperfect information
+
+Imperfect information is not about what a player *sees*. It is about what a
+player can **distinguish**. The formal object is the **information set**: the
+collection of game states a player cannot tell apart when it is their turn to
+move. A game is imperfect-information when some information set contains more
+than one state, because then a strategy cannot be a function of the state — there
+is no single state to be a function of.
+
+Now apply that to hidden-hand FLIPHEX:
+
+- Both decks are **fixed and published**. Each player starts with one tile of
+  each of the 12 arrow patterns; Player 1 additionally holds the joker.
+- Every placement is **public**. A tile that hits the board is visible forever,
+  and its identity is unambiguous.
+
+So at any point I can compute the opponent's hand exactly: it is the published
+deck minus everything they have already played. The information set has **one
+element**. My belief about their hand is a point mass, not a distribution.
+
+Hiding the hand hides nothing. It just makes me do subtraction.
+
+That is the test I now apply, and it generalises well beyond this game:
+
+> **Concealment only creates imperfect information when the concealed thing is
+> not derivable from public history.**
+
+Poker qualifies — the shuffle is a genuine random variable and no amount of
+public history pins down the hole cards. Pokémon TCG qualifies, for the same
+reason: deck order is randomised, so the top card is a real distribution. FLIPHEX
+with hidden hands does not qualify. It is a memory exercise wearing a game-theory
+costume.
+
+## What perfect information actually buys you
+
+Once I stopped trying to escape it, the property turned out to be doing a lot of
+load-bearing work in my design decisions:
+
+| | perfect information | imperfect information |
+|---|---|---|
+| **A strategy is** | a function of the state | a function of the information set |
+| **Solution concept** | pure-strategy equilibrium by backward induction (Zermelo/Kuhn) | generally requires *mixed* strategies; the target is an ε-Nash |
+| **A leaf's value** | `v(s)`, a function of the state alone | must be defined over a belief, not a state |
+| **Search operates on** | states — minimax, alpha-beta | information sets — CFR, ISMCTS |
+| **Transposition table** | sound: the state is a sufficient statistic | the key you can observe is not the state you are in |
+| **"The value of the game"** | a single number | a strategy profile, not a number |
+
+The row that surprised me most is the third one, because it is what licenses
+AlphaZero's most famous simplification. AlphaZero drops random rollouts and
+trusts a learned value network at the leaf. That is only defensible because in a
+perfect-information game the leaf's value *is* a function of the state — there is
+no hidden variable left to average over. Take the same trick to an
+imperfect-information game and you get **strategy fusion**: the search quietly
+assumes it will be allowed to play a different move in each possible world, which
+is exactly the thing the opponent's uncertainty was supposed to prevent.
+
+So "perfect information" is not a limitation to be designed around. It is the
+precondition for an entire family of methods — exact solving, transposition
+tables, learned state values — that simply do not transfer.
+
+## The takeaway
+
+I went looking for a way to make my game harder and found a sharper question
+instead: *is the hidden thing derivable?* If yes, you have added bookkeeping. If
+no, you have changed the mathematics of the game, and most of your algorithmic
+toolbox no longer applies.
+
+Worth checking before designing the variant, not after.
+
+---
+
+**Related:** [`docs/adr/adr-001-perfect-information-scope.md`](../docs/adr/adr-001-perfect-information-scope.md) ·
+[`docs/rules-canonical.md`](../docs/rules-canonical.md) §2 ·
+[`notes/russell-norvig-aima-ch6-adversarial-search.md`](../notes/russell-norvig-aima-ch6-adversarial-search.md) §6.5.1

--- a/writeup/decision-journal.md
+++ b/writeup/decision-journal.md
@@ -9,6 +9,158 @@ Raw material for `writeup/main-writeup.md`.
 
 ---
 
+## 2026-07-31 — Allis reframes the solver: 4×4 is the real target, not 3×3
+
+Filling in the Allis lit-note surfaced four questions from the co-designer, and
+two of them moved ADRs.
+
+**The state-space bound, verified on paper.** Reconstructed the ~4.9 × 10¹⁷
+figure from scratch to answer "why isn't it just 3²⁵?". The answer: a FLIPHEX
+state is *not* colour-per-cell — because flips detach a cell's colour from who
+placed it, the hands (which tiles each player has spent) are independent state.
+`3²⁵ ≈ 8.5 × 10¹¹` is only the board; the hand factor (~5.8 × 10⁵) lifts it to
+`Σ_t C(25,t)·2^t·C(13,⌈t/2⌉)·C(12,⌊t/2⌋) = 4.89 × 10¹⁷`. The `2^t` is the
+upper-bound step — it treats every 2-colouring as reachable, which flip dynamics
+do not guarantee. So the number is an honest *upper bound*, not Allis's exact
+state-space complexity; the true value would need his Monte-Carlo method.
+
+**4×4 is the strategically meaningful exact solve.** Swept the bound across board
+sizes and found the full-enumeration frontier at N ≈ 13–15. 3×3 (9 cells,
+3.1 × 10⁹) is trivially solvable but too cramped for real tactics — it is a
+correctness fixture, not a strategy microcosm, and I was previously letting it
+carry more weight than it can bear. 4×4 (16 cells, 8.3 × 10¹³ full deck /
+9.3 × 10¹⁰ reduced) is both enumerable and rich enough for spatial/tempo play.
+Promoted 4×4 from "attempt" to the primary exact-solve target for H1/H2
+(adr-004 Phase 2 amendment; research.md Phase 2 amendment).
+
+**Allis confirms alpha-beta over pn-search.** FLIPHEX is diverging +
+fixed-termination (the Othello profile). Proof-number search earns its keep on
+sudden-death goal-proving (qubic, go-moku); FLIPHEX has no such goal, so the
+reading *strengthens* adr-004 rather than reopening it. Also corrected adr-004's
+stale "trivial symmetry group" line: the Z/2 mirror (adr-008) is usable for TT
+folding precisely in the endgame DBs, where both P3-y are placed.
+
+**The reduced-deck gap is now explicit (adr-009, Proposed).** "Proportionally
+smaller decks" was hand-waved in adr-004. It swings the 4×4 bound by ~3 orders of
+magnitude and decides whether a reduced solve is a faithful shrink — so it needed
+an ADR, not a default buried in code. Proposed policy: always keep P6 (max flip)
+and P3-y (the chiral symmetry-breaker), fill by ascending arrow count. Flagged
+OPEN-3: is a reduced board a physical variant or a purely computational device?
+
+**Variants promoted to an optional hypothesis (H6).** The co-designer's "what if
+we change the pieces or grow the board?" is the design-space question that lifts
+this above "an agent for my game". Turned it into H6 — a *robustness* claim
+(does the balance keep its sign under bounded perturbation?), guard-railed:
+tested only after H1–H5 settle on the shipped 5×5, shipped game as fixed
+baseline, analyse-don't-redesign. Droppable at lock without touching the spine.
+
+---
+
+## 2026-07-29 — OPEN-2 resolved, and a correction to adr-008
+
+Two things, same day, tightly linked.
+
+**OPEN-2 is resolved.** The two decks were cut from the same mould, so their
+chiral `P3-y` tiles are *identical* (same chirality), not mirror images — both
+players hold `(0,1,3)` on their own face. Consequence: **no deck confound for
+H1**; it is a clean first-move (plus joker) question and does not split into
+H1a/H1b. This clears the last blocker to locking the Phase 2 hypotheses.
+
+**Correction to adr-008.** Working out the OPEN-2 consequence exposed an error I
+had made: I claimed the board's Z/2 mirror gives the *game* a 2× augmentation
+"conditional on OPEN-2." Redoing the arrow algebra, the chiral `P3-y` breaks the
+mirror at the dynamics level **whenever it is still in a hand**, independent of
+OPEN-2 (its reflection {0,3,5} is not a rotation of {0,1,3}, and no player holds
+the reflected tile). The mirror is only a *partial* symmetry — valid on the
+sub-game after both `P3-y` are placed and inert. OPEN-2 governs *seat
+equivalence* (H1), not the augmentation. adr-008, `research.md` (dropped the
+symmetry hypothesis), and the geometry prose were corrected.
+
+Caught it before the lock, which is the point of the discipline — but noting it
+as a genuine over-claim I made and then had to walk back.
+
+---
+
+## 2026-07-29 — The board is not asymmetric: it has a mirror (Z/2)
+
+Studying AlphaZero — which *drops* symmetry augmentation because chess and shogi
+are asymmetric — I stopped trusting the Phase 0 prose and actually computed the
+board's automorphism group (`scripts/check_symmetry.py`). Phase 0 said the
+symmetry group was **trivial**; it is **Z/2**. There is a left-right mirror
+across column C (A↔E, B↔D, C fixed; NE↔NW, SE↔SW). 180° is genuinely not a
+symmetry (columns B/D are staggered half a cell; and 25 is odd, so an involution
+must fix a cell — the mirror fixes column C).
+
+The Phase 0 argument ("A/C/E and B/D have different vertical centres") only ruled
+out symmetries that *mix* the two column groups. The mirror stays within each
+group, so the argument never applied to it. The doc even lists the counterexample
+unknowingly: A1 and E1 are the two degree-2 cells and are each other's mirror
+image.
+
+Recorded as **adr-008 (Proposed)**. The subtle, project-elevating part: the
+board-level mirror is unconditional, but the **game-level** symmetry is
+conditional on **OPEN-2** — the chiral P3-y tile is the one piece whose mirror
+leaves the deck. So OPEN-2 now gates two things: the H1 seat-asymmetry confound
+*and* whether we get the 2× self-play augmentation / mirror-canonical
+transposition. If it holds, FLIPHEX sits between chess (1×) and Go (8×). H1 is
+unaffected either way — the mirror preserves the player to move, so it gives no
+strategy-stealing argument.
+
+This is also the second time a Phase 0 "fact" fell to a concrete check (after the
+flip-rule toggle, adr-007). Pattern noted: validate load-bearing claims by
+computation, not prose.
+
+---
+
+## 2026-07-29 — Thesis reframe: self-play as a game-design instrument
+
+Reading AlphaZero shifted the project's centre of gravity. The compelling story is
+not "apply AlphaZero to my game" (a common exercise) but "use self-play and exact
+search as instruments to *understand and validate the design* of an original,
+un-analysed game" — its first-player balance, joker effect, board geometry, and
+tile distribution. Strong play becomes the means; understanding the design is the
+end. H1/H2/H5 (already design-balance questions) become the spine; H3 is the
+cross-axis honesty check; H4 situates the game; a new optional H6 turns the
+adr-008 mirror into a testable sample-efficiency claim.
+
+Applied to `docs/research.md` as the pre-lock working version (added a Thesis
+section, promoted H1/H2/H5, made H3's multi-seed/Wilson-CI rigour explicit, added
+H6, and corrected the symmetry amendment for adr-008). Guardrails held: analyse,
+do not redesign; the shipped 5×5 first, variants as a stretch; keep a fixed
+benchmark. Not yet locked — the lock waits on `OPEN-2` and lands at
+`v0.3-hypotheses`.
+
+---
+
+## 2026-07-25 — Phase 2 opened
+
+Study phase. Gate check on Phase 1 passed: engine, both agents, and 71 tests
+present; `smoke_selfplay.py` covers the 1000-games criterion. Two carry-overs,
+neither blocking:
+
+- The `01_rules_and_geometry` notebook stays deferred to Phase 7 (decided at
+  Phase 1 close, above).
+- The "heuristic beats random ≥60%" exit criterion was never measured — only
+  random-vs-random invariants were checked. Added as a Phase 1 close item (a
+  short win-rate check) rather than assumed.
+
+No new technique decision enters Phase 2 that needs a `literature-scout`
+dispatch up front — the ADRs already fix the design. Instead the phase's job is
+the *reverse*: read the founding literature (R&N Ch.5, Silver 2017/2018, Allis
+1994, Schaeffer 2007) with one `lit-note` per source, and let any source that
+contradicts adr-004 or adr-005 trigger an ADR amendment. `literature-scout`
+stays available for any ADR the author decides to actively re-litigate.
+
+No experiment runs this phase, so nothing is registered in
+`experiments/registry.md` — the first entries arrive with the Phase 3 solver.
+
+**Blocking exit condition:** OPEN-2 (are the two decks' chiral `P3-y` tiles
+mirror images?) must be resolved on the physical board before H1–H5 lock at
+`v0.3-hypotheses`. It is a live confound for H1 and cannot be deferred past the
+lock.
+
+---
+
 ## 2026-07-25 — Phase 1 closing: scope calls
 
 Engine, both baseline agents, and the full test suite are done, and the flip
@@ -60,9 +212,9 @@ its place in the plan.
 Phase 0 shipped (tag `v0.1-foundation`, clean linear history). Gate check for
 Phase 1 passed with no carry-overs — all 16 Phase 0 deliverables present.
 
-Scope decision: keep the roadmap, `.claude/` config, and `FLIPHEX.pdf` local
-only (gitignored, purged from remote history via force-push). The remote is the
-public artifact; the project direction and tooling are not part of it.
+Scope decision: keep the roadmap, the local tooling config, and `FLIPHEX.pdf`
+local only (gitignored, purged from remote history via force-push). The remote is
+the public artifact; the project direction and tooling are not part of it.
 
 No open technique decision enters Phase 1 — the six ADRs already fix the engine
 design — so no `literature-scout` dispatch here. Literature grounding (and any


### PR DESCRIPTION
Closes the Phase 2 study week. Five sources read with `lit-note` companions, one
cross-source synthesis, and the ADR amendments the reading forced. `docs/research.md`
is left in a lock-ready state; the `v0.3-hypotheses` tag follows this merge and is
what timestamps the pre-registration.

18 commits, 28 files. The headline is not the volume of notes — it is that the
literature falsified four things the project had been assuming.

## Corrections to earlier decisions

| Was | Is | Where |
|---|---|---|
| The board has no symmetries | Z/2 left–right mirror across column C | adr-008 |
| Mirror ⇒ 2× self-play augmentation | Partial symmetry only: the chiral `P3-y` breaks it at game level for ~69% of plies | adr-005 amendment |
| 5×5 unsolvable because ~4.9 × 10¹⁷ states | Wrong axis — checkers has ~1000× more states and *was* weakly solved. Game-tree complexity (~10⁶¹) is what binds | adr-004 amendment |
| "Move ordering drives everything" | True for the depth-limited 5×5 agent; false for the 4×4 exact solve, which is an enumeration problem, not a search problem | adr-004 amendment |

Two numeric errata, both caught by `scripts/layer_profile.py`: the full-deck state
counts for 3×3 and 4×4 had been computed with both hands at 13 tiles, where the rules
give Player 1 thirteen and Player 2 twelve. Reduced-deck figures — the ones that drive
the 4×4 target — are unaffected.

## New ADRs

- **adr-008** — board mirror symmetry (Z/2), and why it is only a partial *game*
  symmetry. Resolves `OPEN-2`: the two decks are identical, so there is no deck
  confound for H1.
- **adr-009** — reduced-deck policy for small board variants. Resolves `OPEN-3`.
- **adr-010** — solver correctness as an architectural concern. Six verification
  mechanisms, two of which check against closed-form definitions rather than against
  another implementation. Drafts the claim wording *before* the result exists.

## Hypotheses

- **H3** now names its comparison set explicitly. As worded before, its cross-axis
  clause would have rested on a single variant.
- **H4** rewritten onto both Allis complexity axes, with the datapoints it is measured
  against.
- Verdict table gains an **evidence class** column and the missing **H6** row.
- Both blockers to locking (`OPEN-2`, `OPEN-3`) are resolved.

## Scripts and tests

- `scripts/check_symmetry.py`, `check_mirror_game_symmetry.py` — establish the
  automorphism group and prove the mirror is endgame-restricted (150 of the 1450
  opening moves have no legal mirror image, all of them `P3-y`).
- `scripts/show_mirror_break.py` — renders the same result on the board.
- `scripts/layer_profile.py` — closed-form state-space profile. Deliberately imports
  nothing from `fliphex`: adr-010 V1 compares this formula against the solver's
  enumerator, and that comparison is only evidence if the two sides are computed by
  different means.
- `tests/test_symmetry.py` — regression cover for the automorphism claims.

## Deferred, deliberately

`exercises/ex01` and `ex02` ship as problem sets with the answers left open. The
derivations are study work and do not gate the hypothesis lock — the figures H4
pre-registers were independently recomputed by `layer_profile.py`, which is the
verification the exercise would otherwise have provided.

`OPEN-1` (confirming all five columns hold five cells) still needs the physical board.
It does not block the lock.

## Verification

`pytest tests/` — 162 passed. `ruff check .` — clean.